### PR TITLE
update version of installation doc

### DIFF
--- a/docs/install-function-mesh.md
+++ b/docs/install-function-mesh.md
@@ -53,7 +53,7 @@ This example shows how to install Function Mesh through [Helm](https://helm.sh/)
 2. Create the custom resource type.
 
     ```shell
-    curl -sSL https://github.com/streamnative/function-mesh/releases/download/v0.1.4/crd.yaml | kubectl apply -f -
+    curl -sSL https://github.com/streamnative/function-mesh/releases/download/v0.1.4/crd.yaml | kubectl create -f -
     ```
 
 3. Install the Function Mesh Operator.

--- a/docs/install-function-mesh.md
+++ b/docs/install-function-mesh.md
@@ -53,7 +53,7 @@ This example shows how to install Function Mesh through [Helm](https://helm.sh/)
 2. Create the custom resource type.
 
     ```shell
-    curl -sSL https://github.com/streamnative/function-mesh/releases/download/v0.1.2/crd.yaml | kubectl apply -f -
+    curl -sSL https://github.com/streamnative/function-mesh/releases/download/v0.1.4/crd.yaml | kubectl apply -f -
     ```
 
 3. Install the Function Mesh Operator.


### PR DESCRIPTION
- update crd download link to v0.1.4.
- use `kubectl create` instead of `apply` since the crd is too large so we can only use `create`.