### PR TITLE
Change kubectl apply commands to kubectl create commands

### DIFF
--- a/docs/connectors/run-connector.md
+++ b/docs/connectors/run-connector.md
@@ -57,7 +57,7 @@ For Pulsar built-in connectors and StreamNative-managed connectors, you can crea
 2. Apply the YAML file to create the sink.
 
     ```bash
-    kubectl apply -f /path/to/sink-sample.yaml
+    kubectl create -f /path/to/sink-sample.yaml
     ```
 
 3. Check whether the sink is created successfully.
@@ -260,7 +260,7 @@ For self-built connectors, you can create them based on how you package them.
 2. Apply the YAML file to create the sink connector.
 
     ```bash
-    kubectl apply -f /path/to/sink-sample.yaml
+    kubectl create -f /path/to/sink-sample.yaml
     ```
 
 3. Check whether the sink connector is created successfully.

--- a/docs/function-mesh/run-function-mesh.md
+++ b/docs/function-mesh/run-function-mesh.md
@@ -100,7 +100,7 @@ To create a Function Mesh, follow these steps.
 2. Apply the YAML file to create the Function Mesh.
 
     ```shell
-    kubectl apply -f /path/to/functionmesh-sample.yaml
+    kubectl create -f /path/to/functionmesh-sample.yaml
     ```
 
 3. Check whether the Function Mesh is created successfully.

--- a/docs/functions/run-function/run-go-function.md
+++ b/docs/functions/run-function/run-go-function.md
@@ -197,7 +197,7 @@ After packaging your Pulsar Go Functions, you can submit your Go Functions to a 
 2. Apply the YAML file to create the Go Functions.
 
     ```bash
-    kubectl apply -f /path/to/YAML/file
+    kubectl create -f /path/to/YAML/file
     ```
 
 3. Check whether the Go Functions is created successfully.

--- a/docs/functions/run-function/run-java-function.md
+++ b/docs/functions/run-function/run-java-function.md
@@ -221,7 +221,7 @@ After packaging your Pulsar Functions, you can submit your Pulsar Functions to a
 2. Apply the YAML file to create the Java Functions.
 
     ```bash
-    kubectl apply -f /path/to/YAML/file
+    kubectl create -f /path/to/YAML/file
     ```
 
 3. Check whether the Java Functions is created successfully.

--- a/docs/functions/run-function/run-python-function.md
+++ b/docs/functions/run-function/run-python-function.md
@@ -190,7 +190,7 @@ After packaging your Pulsar Functions, you can submit your Pulsar Functions to a
 2. Apply the YAML file to create the Python Functions.
 
     ```bash
-    kubectl apply -f /path/to/YAML/file
+    kubectl create -f /path/to/YAML/file
     ```
 
 3. Check whether the Python Functions is created successfully.

--- a/docs/install-function-mesh.md
+++ b/docs/install-function-mesh.md
@@ -105,7 +105,7 @@ This example shows how to install Function Mesh through [Helm](https://helm.sh/)
     1. Submit a sample CRD to the Pulsar cluster.
 
         ```bash
-        kubectl apply -f config/samples/compute_v1alpha1_function.yaml
+        kubectl create -f config/samples/compute_v1alpha1_function.yaml
         ```
 
     2. Verify your submission with the `kubectl` command, and you can see that the Function pod is running.

--- a/docs/migration/migrate-function.md
+++ b/docs/migration/migrate-function.md
@@ -89,8 +89,8 @@ This document describes how to build the tool from the source code and how to us
           # other function config
         ```
 
-After the YAML file is generated, you can use the `kubectl apply -f` command to create the function.
+After the YAML file is generated, you can use the `kubectl create -f` command to create the function.
 
 ```shell
-kubectl apply -f /path/to/function-sample.yaml
+kubectl create -f /path/to/function-sample.yaml
 ```

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -26,7 +26,7 @@ In CRDs, the `replicas` parameter is used to specify the number of Pods (Pulsar 
     kubectl scale --replicas="" pod/POD_NAME
     ```
 
-- Update the value of the `replicas` parameter in the CRD and re-submit the CRD with the `kubectl apply -f` command.
+- Update the value of the `replicas` parameter in the CRD and re-submit the CRD with the `kubectl create -f` command.
 
 ## Autoscaling
 
@@ -64,7 +64,7 @@ This example shows how to auto-scale the number of Pods running Pulsar Functions
 2. Apply the configurations.
 
     ```bash
-    kubectl apply -f path/to/source-sample.yaml
+    kubectl create -f path/to/source-sample.yaml
     ```
 
 ### Auto-scale Pulsar connectors
@@ -106,5 +106,5 @@ This example shows how to auto-scale the number of Pods for running a Pulsar sou
 2. Apply the configurations.
 
     ```bash
-    kubectl apply -f path/to/source-sample.yaml
+    kubectl create -f path/to/source-sample.yaml
     ```


### PR DESCRIPTION
In PR #65, the `kubectl apply` command is changed to `kubectl create `command. Update commands in other related docs.