### PR TITLE
Update docs for v0.1.4 and v0.1.5 releases

### DIFF
--- a/versioned_docs/version-0.1.4/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.1.4/connectors/io-crd-config/sink-crd-config.md
@@ -14,13 +14,12 @@ This table lists sink configurations.
 | `name` | The name of a sink connector. |
 | `classname` | The class name of a sink connector. |
 | `tenant` | The tenant of a sink connector. |
-| `Replicas`| The number of Pulsar instances that you want to run this sink connector. |
+| `Replicas`| The number of instances that you want to run this sink connector. By default, the `Replicas` is set to `1`. |
 | `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `LogTopic` | The topic to which the logs of a sink connector are produced. |
 | `SinkConfig` | The map to a ConfigMap specifying the configuration of a sink connector. |
 | `Timeout` | The message timeout in milliseconds. |
 | `NegativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. |
+| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`. |
 | `MaxMessageRetry` | How many times to process a message before giving up. |
 | `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
 | `RetainOrdering` | The sink connector consumes and processes messages in order. |

--- a/versioned_docs/version-0.1.4/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.1.4/connectors/io-crd-config/source-crd-config.md
@@ -14,9 +14,8 @@ This table lists source configurations.
 | `name` | The name of a source connector. |
 | `classname` | The class name of a source connector. |
 | `tenant` | The tenant of a source connector. |
-| `Replicas`| The number of Pulsar instances that you want to run this source connector. |
+| `Replicas`| The number of instances that you want to run this source connector. By default, the `Replicas` is set to `1`. |
 | `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `LogTopic` | The topic to which the logs of a source connector are produced. |
 | `SourceConfig` | The map to a ConfigMap specifying the configuration of a source connector. |
 | `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
 

--- a/versioned_docs/version-0.1.4/connectors/run-connector.md
+++ b/versioned_docs/version-0.1.4/connectors/run-connector.md
@@ -215,7 +215,6 @@ For self-built connectors, you can create them based on how you package them.
         MaxPendingAsyncRequests: 1000
         replicas: 1
         maxReplicas: 1
-        logTopic: persistent://public/default/logging-connector-logs
         input:
           topics:
           - persistent://public/default/input
@@ -243,7 +242,6 @@ For self-built connectors, you can create them based on how you package them.
         MaxPendingAsyncRequests: 1000
         replicas: 1
         maxReplicas: 1
-        logTopic: persistent://public/default/logging-connector-logs
         input:
           topics:
           - persistent://public/default/input

--- a/versioned_docs/version-0.1.4/functions/function-crd.md
+++ b/versioned_docs/version-0.1.4/functions/function-crd.md
@@ -16,13 +16,13 @@ This table lists Pulsar Function configurations.
 | `classname` | The class name of a Pulsar Function. |
 | `tenant` | The tenant of a Pulsar Function. |
 | `namespace` | The namespace of a Pulsar Function. |
-| `Replicas`| The number of Pulsar instances that you want to run this Pulsar Function. |
+| `Replicas`| The number of instances that you want to run this Pulsar Function. By default, the `Replicas` is set to `1`. |
 | `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
 | `Timeout` | The message timeout in milliseconds. |
 | `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
 | `FuncConfig` | The map to a ConfigMap specifying the configuration of a Pulsar function. |
 | `LogTopic` | The topic to which the logs of a Pulsar Function are produced. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. |
+| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`. |
 | `MaxMessageRetry` | How many times to process a message before giving up. |
 | `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
 | `RetainOrdering` | Function consumes and processes messages in order. |

--- a/versioned_docs/version-0.1.5/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.1.5/connectors/io-crd-config/sink-crd-config.md
@@ -14,13 +14,12 @@ This table lists sink configurations.
 | `name` | The name of a sink connector. |
 | `classname` | The class name of a sink connector. |
 | `tenant` | The tenant of a sink connector. |
-| `Replicas`| The number of Pulsar instances that you want to run this sink connector. |
+| `Replicas`| The number of instances that you want to run this sink connector. By default, the `Replicas` is set to `1`. |
 | `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `LogTopic` | The topic to which the logs of a sink connector are produced. |
 | `SinkConfig` | The map to a ConfigMap specifying the configuration of a sink connector. |
 | `Timeout` | The message timeout in milliseconds. |
 | `NegativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. |
+| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`. |
 | `MaxMessageRetry` | How many times to process a message before giving up. |
 | `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
 | `RetainOrdering` | The sink connector consumes and processes messages in order. |

--- a/versioned_docs/version-0.1.5/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.1.5/connectors/io-crd-config/source-crd-config.md
@@ -14,9 +14,8 @@ This table lists source configurations.
 | `name` | The name of a source connector. |
 | `classname` | The class name of a source connector. |
 | `tenant` | The tenant of a source connector. |
-| `Replicas`| The number of Pulsar instances that you want to run this source connector. |
+| `Replicas`| The number of instances that you want to run this source connector. By default, the `Replicas` is set to `1`. |
 | `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `LogTopic` | The topic to which the logs of a source connector are produced. |
 | `SourceConfig` | The map to a ConfigMap specifying the configuration of a source connector. |
 | `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
 

--- a/versioned_docs/version-0.1.5/connectors/run-connector.md
+++ b/versioned_docs/version-0.1.5/connectors/run-connector.md
@@ -216,7 +216,6 @@ For self-built connectors, you can create them based on how you package them.
         MaxPendingAsyncRequests: 1000
         replicas: 1
         maxReplicas: 1
-        logTopic: persistent://public/default/logging-connector-logs
         input:
           topics:
           - persistent://public/default/input
@@ -245,7 +244,6 @@ For self-built connectors, you can create them based on how you package them.
         MaxPendingAsyncRequests: 1000
         replicas: 1
         maxReplicas: 1
-        logTopic: persistent://public/default/logging-connector-logs
         input:
           topics:
           - persistent://public/default/input

--- a/versioned_docs/version-0.1.5/functions/function-crd.md
+++ b/versioned_docs/version-0.1.5/functions/function-crd.md
@@ -16,13 +16,13 @@ This table lists Pulsar Function configurations.
 | `classname` | The class name of a Pulsar Function. |
 | `tenant` | The tenant of a Pulsar Function. |
 | `namespace` | The namespace of a Pulsar Function. |
-| `Replicas`| The number of Pulsar instances that you want to run this Pulsar Function. |
+| `Replicas`| The number of instances that you want to run this Pulsar Function. By default, the `Replicas` is set to `1`. |
 | `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
 | `Timeout` | The message timeout in milliseconds. |
 | `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
 | `FuncConfig` | The map to a ConfigMap specifying the configuration of a Pulsar function. |
 | `LogTopic` | The topic to which the logs of a Pulsar Function are produced. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. |
+| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`. |
 | `MaxMessageRetry` | How many times to process a message before giving up. |
 | `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
 | `RetainOrdering` | Function consumes and processes messages in order. |

--- a/versioned_docs/version-0.1.5/releases/release-note-0-1-5.md
+++ b/versioned_docs/version-0.1.5/releases/release-note-0-1-5.md
@@ -5,7 +5,7 @@ id: release-note-0-1-5
 ---
 
 
-Here are some highlights of this release. For a full list of updates available for Release V0.1.5, check out [here](https://github.com/streamnative/function-mesh/releases/tag/v0.1.5)
+Here are some highlights of this release. For a full list of updates available for Release v0.1.5, check out [here](https://github.com/streamnative/function-mesh/releases/tag/v0.1.5)
 
 ## Remove descriptions from Function Mesh CRDs
 


### PR DESCRIPTION
Update docs for FunctionMesh release v0.1.5 and v0.1.4:

Doc update for doc-required PRs (remove logTopic from connector CRD function-mesh#242), (fix NPE when not set AutoAck function-mesh#234)