### PR TITLE
Add docs for Function Mesh v0.1.8 release

### DIFF
--- a/docs/function-mesh-worker/function-mesh-worker-overview.md
+++ b/docs/function-mesh-worker/function-mesh-worker-overview.md
@@ -4,6 +4,8 @@ category: function-mesh-worker
 id: function-mesh-worker-overview
 ---
 
+This document gives a brief introduction into Function Mesh Worker service.
+
 # What is Function Mesh Worker service
 
 Function Mesh Worker service is a plug-in for Pulsar. It is similar to Pulsar Function Worker service but uses Function Mesh operators to schedule and run functions. Function Mesh Worker service enables you to use the [`pulsar-admin`](https://pulsar.apache.org/docs/en/pulsar-admin/) or [`pulsarctl`](https://docs.streamnative.io/pulsarctl/v2.7.0.7/) CLI tools to manage Pulsar functions and connectors in Function Mesh.

--- a/docs/function-mesh-worker/function-mesh-worker-overview.md
+++ b/docs/function-mesh-worker/function-mesh-worker-overview.md
@@ -1,0 +1,16 @@
+---
+title: Function Mesh Worker service overview
+category: function-mesh-worker
+id: function-mesh-worker-overview
+---
+
+# What is Function Mesh Worker service
+
+Function Mesh Worker service is a plug-in for Pulsar. It is similar to Pulsar Function Worker service but uses Function Mesh operators to schedule and run functions. Function Mesh Worker service enables you to use the [`pulsar-admin`](https://pulsar.apache.org/docs/en/pulsar-admin/) or [`pulsarctl`](https://docs.streamnative.io/pulsarctl/v2.7.0.7/) CLI tools to manage Pulsar functions and connectors in Function Mesh.
+
+# How Function Mesh Worker service works
+
+The following figure illustrates how Function Mesh Worker service works with Pulsar proxy, converts and forwards function and / or connector admin requests to the Kubernetes cluster. The benefit of this approach is that you do not need to change the way you create and submit functions and / or connectors.
+
+![Function Mesh Workflow](./../assets/function-mesh-workflow.png)
+

--- a/docs/releases/release-note-0-1-8.md
+++ b/docs/releases/release-note-0-1-8.md
@@ -5,3 +5,9 @@ id: release-note-0-1-8
 ---
 
 Here are some highlights of this release. For a full list of updates available for Release v0.1.8, check out [here](https://github.com/streamnative/function-mesh/releases/tag/v0.1.8).
+
+# Support running Pulsar functions and connectors with a default or a customized service account in Mesh Worker service
+
+In this release, we added `defaultServiceAccountName` to `MeshWorkerServiceCustomConfig` to allow users to set the default service account for running the Pod.
+
+And, we also added `serviceAccountName` to `CustomRuntimeOptions` to allow users to use a specific service account to run the Pod. 

--- a/docs/releases/release-note-0-1-8.md
+++ b/docs/releases/release-note-0-1-8.md
@@ -1,0 +1,7 @@
+---
+title: Release notes v0.1.8
+category: releases
+id: release-note-0-1-8
+---
+
+Here are some highlights of this release. For a full list of updates available for Release v0.1.8, check out [here](https://github.com/streamnative/function-mesh/releases/tag/v0.1.8).

--- a/sidebars.js
+++ b/sidebars.js
@@ -48,6 +48,11 @@ module.exports = {
       label: 'Meshes',
       items: ['function-mesh/function-mesh-overview', 'function-mesh/function-mesh-crd', 'function-mesh/run-function-mesh'],
     },
+    {
+      type: 'category',
+      label: 'Function Mesh Worker',
+      items: ['function-mesh-worker/function-mesh-worker overview'],
+    },
     'scaling',
     {
       type: 'category',

--- a/sidebars.js
+++ b/sidebars.js
@@ -51,7 +51,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Function Mesh Worker',
-      items: ['function-mesh-worker/function-mesh-worker overview'],
+      items: ['function-mesh-worker/function-mesh-worker-overview'],
     },
     'scaling',
     {

--- a/sidebars.js
+++ b/sidebars.js
@@ -62,7 +62,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Releases',
-      items: ['releases/release-note-0-1-4', 'releases/release-note-0-1-5', 'releases/release-note-0-1-6'],
+      items: ['releases/release-note-0-1-4', 'releases/release-note-0-1-5', 'releases/release-note-0-1-6', 'releases/release-note-0-1-7', 'releases/release-note-0-1-8'],
     },
   ],
 }


### PR DESCRIPTION
Update docs for Function Mesh v0.1.8 release.
Add function Mesh worker service overview doc. This doc has been reviewed technically and editorially through the google doc.
Add release note v0.1.8