### PR TITLE
Update docs for `secretsMap` option support

### DIFF
--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -63,7 +63,7 @@ If the node where a Pod is running has enough of a resource available, it is pos
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider` which can be used by `context.getSecret()` in Pulsar functions and connectors.
+Function Mesh provides the `SecretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
 
 The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
 
@@ -85,7 +85,7 @@ metadata:
 type: Opaque
 ```
 
-To use it in Pulsar Functions in a security way, you can define the `SecretsMap` in the Custom Resource:
+To use it in Pulsar Functions in a secure way, you can define the `SecretsMap` in the Custom Resource:
 
 ```yaml
 secretsMap:

--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -63,30 +63,44 @@ If the node where a Pod is running has enough of a resource available, it is pos
 
 ## Secrets
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret.
+Function Mesh provides the `SecretsMap` field for Function, Source and Sink in the CRD definition. You can refer to the created secret under the same namespace and the controller can include those referred secrets as environment variables. You can specify the `data.username` and `data.password` fields when creating a secret, as shown below.
 
-To use a secret in an environment variable in a Pod, follow these steps.
+```yaml
+apiVersion: v1
+data:
+  username: <secret_key>
+  password: <secret_password>
+kind: Secret
+metadata:
+  name: <secret_name>
+type: Opaque
+```
 
-1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
-2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.
-3. Modify your image and or command line so that the program looks for values in the specified environment variables.
+This table lists configurations about the `SecretsMap` field.
 
-Pulsar clusters support using TLS or other authentication plugin for authentication.
+| Field | Description |
+| --- | --- |
+| `name` | The name of the environment variable. <br />- `path`: the secret name. <br>- `key`: the key in the secret, which is defined using the `data.username` field. |
+| `pwd` | The password infomation of the secret. <br />- `path`: the secret name. <br>- `password`: the password in the secret, which is defined using the `data.password` field.|
+
+## Authentication
+
+Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
     | Field | Description |
     | --- | --- |
-    | tlsAllowInsecureConnection | Allow insecure TLS connection. |
-    | tlsHostnameVerificationEnable | Enable hostname verification. |
-    | tlsTrustCertsFilePath | The path of the TLS trust certificate file. |
+    | `tlsAllowInsecureConnection` | Allow insecure TLS connection. |
+    | `tlsHostnameVerificationEnable` | Enable hostname verification. |
+    | `tlsTrustCertsFilePath` | The path of the TLS trust certificate file. |
 
-- Auth Secret
+- Authentication Secret
 
     | Field | Description |
     | --- | --- |
-    | clientAuthenticationPlugin | Client authentication plugin. |
-    | clientAuthenticationParameters | Client authentication parameters. |
+    | `clientAuthenticationPlugin` | The client authentication plugin. |
+    | `clientAuthenticationParameters` | The client authentication parameters. |
 
 ## Packages
 

--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -80,8 +80,8 @@ This table lists configurations about the `SecretsMap` field.
 
 | Field | Description |
 | --- | --- |
-| `name` | The name of the environment variable. <br />- `path`: the secret name. <br>- `key`: the key in the secret, which is defined using the `data.username` field. |
-| `pwd` | The password infomation of the secret. <br />- `path`: the secret name. <br>- `password`: the password in the secret, which is defined using the `data.password` field.|
+| `name` | The name of the environment variable. <br />- `path`: the secret name. <br />- `key`: the key in the secret, which is defined using the `data.username` field. |
+| `pwd` | The password infomation of the secret. <br />- `path`: the secret name. <br />- `password`: the password in the secret, which is defined using the `data.password` field.|
 
 ## Authentication
 

--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -91,13 +91,13 @@ To use it in Pulsar Functions in a security way, you can define the `SecretsMap`
 secretsMap:
   username:
     path: credential-secret
-    key: foo
+    key: username
   password:
     path: credential-secret
-    key: bar
+    key: password
 ```
 
-Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("username")` to get the secret value.
+Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("username")` to get the secret value (`foo`).
 
 ## Authentication
 

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -84,13 +84,13 @@ To use it in Pulsar Functions in a security way, you can define the `SecretsMap`
 secretsMap:
   username:
     path: credential-secret
-    key: foo
+    key: username
   password:
     path: credential-secret
-    key: bar
+    key: password
 ```
 
-Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("username")` to get the secret value.
+Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("username")` to get the secret value (`foo`).
 
 ## Authentication
 

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -56,30 +56,44 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret.
+Function Mesh provides the `SecretsMap` field for Function, Source and Sink in the CRD definition. You can refer to the created secret under the same namespace and the controller can include those referred secrets as environment variables. You can specify the `data.username` and `data.password` fields when creating a secret, as shown below.
 
-To use a secret in an environment variable in a Pod, follow these steps.
+```yaml
+apiVersion: v1
+data:
+  username: <secret_key>
+  password: <secret_password>
+kind: Secret
+metadata:
+  name: <secret_name>
+type: Opaque
+```
 
-1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
-2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.
-3. Modify your image and/or command line so that the program looks for values in the specified environment variables.
+This table lists configurations about the `SecretsMap` field.
 
-Pulsar clusters support using TLS or other authentication plugin for authentication.
+| Field | Description |
+| --- | --- |
+| `name` | The name of the environment variable. <br />- `path`: the secret name. <br>- `key`: the key in the secret, which is defined using the `data.username` field. |
+| `pwd` | The password infomation of the secret. <br />- `path`: the secret name. <br>- `password`: the password in the secret, which is defined using the `data.password` field.|
+
+## Authentication
+
+Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
     | Field | Description |
     | --- | --- |
-    | tlsAllowInsecureConnection | Allow insecure TLS connection. |
-    | tlsHostnameVerificationEnable | Enable hostname verification. |
-    | tlsTrustCertsFilePath | The path of the TLS trust certificate file. |
+    | `tlsAllowInsecureConnection` | Allow insecure TLS connection. |
+    | `tlsHostnameVerificationEnable` | Enable hostname verification. |
+    | `tlsTrustCertsFilePath` | The path of the TLS trust certificate file. |
 
-- Auth Secret
+- Authentication Secret
 
     | Field | Description |
     | --- | --- |
-    | clientAuthenticationPlugin | Client authentication plugin. |
-    | clientAuthenticationParameters | Client authentication parameters. |
+    | `clientAuthenticationPlugin` | The client authentication plugin. |
+    | `clientAuthenticationParameters` | The client authentication parameters. |
 
 ## Packages
 

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -56,7 +56,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider` which can be used by `context.getSecret()` in Pulsar functions and connectors.
+Function Mesh provides the `SecretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
 
 The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
 
@@ -78,7 +78,7 @@ metadata:
 type: Opaque
 ```
 
-To use it in Pulsar Functions in a security way, you can define the `SecretsMap` in the Custom Resource:
+To use it in Pulsar Functions in a secure way, you can define the `SecretsMap` in the Custom Resource:
 
 ```yaml
 secretsMap:

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -73,8 +73,8 @@ This table lists configurations about the `SecretsMap` field.
 
 | Field | Description |
 | --- | --- |
-| `name` | The name of the environment variable. <br />- `path`: the secret name. <br>- `key`: the key in the secret, which is defined using the `data.username` field. |
-| `pwd` | The password infomation of the secret. <br />- `path`: the secret name. <br>- `password`: the password in the secret, which is defined using the `data.password` field.|
+| `name` | The name of the environment variable. <br />- `path`: the secret name. <br />- `key`: the key in the secret, which is defined using the `data.username` field. |
+| `pwd` | The password infomation of the secret. <br />- `path`: the secret name. <br />- `password`: the password in the secret, which is defined using the `data.password` field.|
 
 ## Authentication
 

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -56,25 +56,41 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source and Sink in the CRD definition. You can refer to the created secret under the same namespace and the controller can include those referred secrets as environment variables. You can specify the `data.username` and `data.password` fields when creating a secret, as shown below.
+Function Mesh provides the `SecretsMap` field for Function, Source and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider` which can be used by `context.getSecret()` in Pulsar functions and connectors.
+
+The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
+
+| Field | Description |
+| --- | --- |
+| `path` | The name of the secret in the Pod's namespace to select from. |
+| `key` | The key of the secret to select from. It must be a valid secret key.|
+
+Suppose that there is a Kubernetes Secret named `credential-secret` defined as below:
 
 ```yaml
 apiVersion: v1
 data:
-  username: <secret_key>
-  password: <secret_password>
+  username: foo
+  password: bar
 kind: Secret
 metadata:
-  name: <secret_name>
+  name: credential-secret
 type: Opaque
 ```
 
-This table lists configurations about the `SecretsMap` field.
+To use it in Pulsar Functions in a security way, you can define the `SecretsMap` in the Custom Resource:
 
-| Field | Description |
-| --- | --- |
-| `name` | The name of the environment variable. <br />- `path`: the secret name. <br />- `key`: the key in the secret, which is defined using the `data.username` field. |
-| `pwd` | The password infomation of the secret. <br />- `path`: the secret name. <br />- `password`: the password in the secret, which is defined using the `data.password` field.|
+```yaml
+secretsMap:
+  username:
+    path: credential-secret
+    key: foo
+  password:
+    path: credential-secret
+    key: bar
+```
+
+Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("username")` to get the secret value.
 
 ## Authentication
 

--- a/docs/function-mesh-worker/deploy-mesh-worker.md
+++ b/docs/function-mesh-worker/deploy-mesh-worker.md
@@ -14,14 +14,14 @@ This document describes how to deploy the Function Mesh Worker service.
 > - You need to manually manage the [`ConfigMap`](/functions/function-crd.md#cluster-location), such as the Pulsar service URL.
 > - A Pulsar cluster with the Function Mesh Worker service should be the same Kubernetes cluster where the Function Mesh Operator is deployed.
 
-# Prerequisite
+## Prerequisite
 
 To deploy the Function Mesh Worker service, ensure that these services are already running in your environment.
 
 - Apache Pulsar cluster (v2.8.0 or higher version)
 - Function Mesh operator
 
-# Deploy Function Mesh Worker service with Pulsar brokers
+## Deploy Function Mesh Worker service with Pulsar brokers
 
 The following diagram illustrates how to deploy the Function Mesh Worker service along with Pulsar brokers.
 
@@ -29,7 +29,7 @@ The following diagram illustrates how to deploy the Function Mesh Worker service
 
 Function Mesh Worker service can forward requests to the Kubernetes cluster. After you start the Function Mesh Worker service, you can use the [`pulsar-admin`](https://pulsar.apache.org/docs/en/pulsar-admin/) CLI tool to manage Pulsar functions and connectors.
 
-## Configure the Function Mesh Worker service
+### Configure Function Mesh Worker service
 
 You can customize the Function Mesh Worker service using `functionsWorkerServiceCustomConfigs` in the `functions_worker.yml` manifest. This table lists available configurations.
 
@@ -49,7 +49,7 @@ You can customize the Function Mesh Worker service using `functionsWorkerService
 | `functionRunnerImages` | Map < String, String > | No | {} (empty string)| The runner image to run the Pulsar Function instances. |
 | `imagePullSecrets` | List< V1LocalObjectReference > | No | [] (empty string) | An optional list of references to secrets in the same namespace to pull images used by `PodSpec`. |
 
-## Start the Function Mesh Worker service
+### Start Function Mesh Worker service
 
 This section describes how to start the Function Mesh Worker service after you configure it.
 

--- a/docs/function-mesh-worker/function-mesh-worker-overview.md
+++ b/docs/function-mesh-worker/function-mesh-worker-overview.md
@@ -6,17 +6,17 @@ id: function-mesh-worker-overview
 
 This document gives a brief introduction into Function Mesh Worker service.
 
-# What is Function Mesh Worker service
+## What is Function Mesh Worker service
 
 Function Mesh Worker service is a plug-in for Pulsar. It is similar to Pulsar Function Worker service but uses Function Mesh operators to schedule and run functions. Function Mesh Worker service enables you to use the [`pulsar-admin`](https://pulsar.apache.org/docs/en/pulsar-admin/) or [`pulsarctl`](https://docs.streamnative.io/pulsarctl/v2.7.0.7/) CLI tools to manage Pulsar functions and connectors in Function Mesh.
 
-# How Function Mesh Worker service works
+## How Function Mesh Worker service works
 
 The following figure illustrates how Function Mesh Worker service works with Pulsar proxy, converts and forwards function and / or connector admin requests to the Kubernetes cluster. The benefit of this approach is that you do not need to change the way you create and submit functions and / or connectors.
 
 ![Function Mesh Workflow](./../assets/function-mesh-workflow.png)
 
-# Version matrix
+## Version matrix
 
 This table lists the version mapping relationships between Function Mesh and Function Mesh Worker service.
 

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -84,7 +84,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider` which can be used by `context.getSecret()` in Pulsar functions and connectors.
+Function Mesh provides the `SecretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
 
 The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
 
@@ -106,7 +106,7 @@ metadata:
 type: Opaque
 ```
 
-To use it in Pulsar Functions in a security way, you can define the `SecretsMap` in the Custom Resource:
+To use it in Pulsar Functions in a secure way, you can define the `SecretsMap` in the Custom Resource:
 
 ```yaml
 secretsMap:

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -112,13 +112,13 @@ To use it in Pulsar Functions in a security way, you can define the `SecretsMap`
 secretsMap:
   username:
     path: credential-secret
-    key: foo
+    key: username
   password:
     path: credential-secret
-    key: bar
+    key: password
 ```
 
-Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("username")` to get the secret value.
+Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("username")` to get the secret value (`foo`).
 
 ## Authentication
 

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -33,8 +33,6 @@ This table lists Pulsar Function configurations.
 | `CleanupSubscription` | Configure whether to clean up subscriptions. |
 | `SubscriptionPosition` | The subscription position. |
 
-This section lists CRD configurations that are common for Pulsar functions, sources, sinks, and Function Mesh.
-
 ## Images
 
 This section describes image options available for Pulsar Function, source, sink and Function Mesh CRDs.
@@ -86,30 +84,44 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret. 
+Function Mesh provides the `SecretsMap` field for Function, Source and Sink in the CRD definition. You can refer to the created secret under the same namespace and the controller can include those referred secrets as environment variables. You can specify the `data.username` and `data.password` fields when creating a secret, as shown below.
 
-To use a secret in an environment variable in a Pod, follow these steps.
+```yaml
+apiVersion: v1
+data:
+  username: <secret_key>
+  password: <secret_password>
+kind: Secret
+metadata:
+  name: <secret_name>
+type: Opaque
+```
 
-1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
-2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.
-3. Modify your image and/or command line so that the program looks for values in the specified environment variables.
+This table lists configurations about the `SecretsMap` field.
 
-Pulsar clusters supports using TLS or other authentication plugin for authentication.
+| Field | Description |
+| --- | --- |
+| `name` | The name of the environment variable. <br />- `path`: the secret name. <br>- `key`: the key in the secret, which is defined using the `data.username` field. |
+| `pwd` | The password infomation of the secret. <br />- `path`: the secret name. <br>- `password`: the password in the secret, which is defined using the `data.password` field.|
+
+## Authentication
+
+Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
     | Field | Description |
     | --- | --- |
-    | tlsAllowInsecureConnection | Allow insecure TLS connection. |
-    | tlsHostnameVerificationEnable | Enable hostname verification. |
-    | tlsTrustCertsFilePath | The path of the TLS trust certificate file. |
+    | `tlsAllowInsecureConnection` | Allow insecure TLS connection. |
+    | `tlsHostnameVerificationEnable` | Enable hostname verification. |
+    | `tlsTrustCertsFilePath` | The path of the TLS trust certificate file. |
 
-- Auth Secret
+- Authentication Secret
 
     | Field | Description |
     | --- | --- |
-    | clientAuthenticationPlugin | Client authentication plugin. |
-    | clientAuthenticationParameters | Client authentication parameters. |
+    | `clientAuthenticationPlugin` | The client authentication plugin. |
+    | `clientAuthenticationParameters` | The client authentication parameters. |
 
 ## Packages
 

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -101,8 +101,8 @@ This table lists configurations about the `SecretsMap` field.
 
 | Field | Description |
 | --- | --- |
-| `name` | The name of the environment variable. <br />- `path`: the secret name. <br>- `key`: the key in the secret, which is defined using the `data.username` field. |
-| `pwd` | The password infomation of the secret. <br />- `path`: the secret name. <br>- `password`: the password in the secret, which is defined using the `data.password` field.|
+| `name` | The name of the environment variable. <br />- `path`: the secret name. <br />- `key`: the key in the secret, which is defined using the `data.username` field. |
+| `pwd` | The password infomation of the secret. <br />- `path`: the secret name. <br />- `password`: the password in the secret, which is defined using the `data.password` field.|
 
 ## Authentication
 

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -84,25 +84,41 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source and Sink in the CRD definition. You can refer to the created secret under the same namespace and the controller can include those referred secrets as environment variables. You can specify the `data.username` and `data.password` fields when creating a secret, as shown below.
+Function Mesh provides the `SecretsMap` field for Function, Source and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider` which can be used by `context.getSecret()` in Pulsar functions and connectors.
+
+The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
+
+| Field | Description |
+| --- | --- |
+| `path` | The name of the secret in the Pod's namespace to select from. |
+| `key` | The key of the secret to select from. It must be a valid secret key.|
+
+Suppose that there is a Kubernetes Secret named `credential-secret` defined as below:
 
 ```yaml
 apiVersion: v1
 data:
-  username: <secret_key>
-  password: <secret_password>
+  username: foo
+  password: bar
 kind: Secret
 metadata:
-  name: <secret_name>
+  name: credential-secret
 type: Opaque
 ```
 
-This table lists configurations about the `SecretsMap` field.
+To use it in Pulsar Functions in a security way, you can define the `SecretsMap` in the Custom Resource:
 
-| Field | Description |
-| --- | --- |
-| `name` | The name of the environment variable. <br />- `path`: the secret name. <br />- `key`: the key in the secret, which is defined using the `data.username` field. |
-| `pwd` | The password infomation of the secret. <br />- `path`: the secret name. <br />- `password`: the password in the secret, which is defined using the `data.password` field.|
+```yaml
+secretsMap:
+  username:
+    path: credential-secret
+    key: foo
+  password:
+    path: credential-secret
+    key: bar
+```
+
+Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("username")` to get the secret value.
 
 ## Authentication
 

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -44,7 +44,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
-  This table lists built-in CPU-based autoscaling metrics. If these metrics cannot meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
+  This table lists built-in memory-based autoscaling metrics. If these metrics cannot meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
   
   | Option | Description |
   | --- | --- |

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -34,7 +34,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 
 - CPU usage: auto-scale the number of Pods based on CPU utilization.
   
-  This table lists built-in CPU-based autoscaling metrics. If these metrics cannot meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
+  This table lists built-in CPU-based autoscaling metrics. If these metrics do not meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
   
   | Option | Description |
   | --- | --- |
@@ -44,7 +44,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
-  This table lists built-in memory-based autoscaling metrics. If these metrics cannot meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
+  This table lists built-in memory-based autoscaling metrics. If these metrics do not meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
   
   | Option | Description |
   | --- | --- |

--- a/versioned_docs/version-0.1.4/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.1.4/connectors/io-crd-config/sink-crd-config.md
@@ -62,9 +62,9 @@ If the node where a Pod is running has enough of a resource available, it is pos
 
 ## Secrets
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret.
+In Function Mesh, the secret is defined through a `secretsMap`. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume.
 
-To use a secret in an environment variable in a Pod, follow these steps.
+To use a secret as an environment variable in a Pod, follow these steps.
 
 1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
 2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.

--- a/versioned_docs/version-0.1.4/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.1.4/connectors/io-crd-config/source-crd-config.md
@@ -54,9 +54,9 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret.
+In Function Mesh, the secret is defined through a `secretsMap`. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume.
 
-To use a secret in an environment variable in a Pod, follow these steps.
+To use a secret as an environment variable in a Pod, follow these steps.
 
 1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
 2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.

--- a/versioned_docs/version-0.1.4/functions/function-crd.md
+++ b/versioned_docs/version-0.1.4/functions/function-crd.md
@@ -32,8 +32,6 @@ This table lists Pulsar Function configurations.
 | `CleanupSubscription` | Configure whether to clean up subscriptions. |
 | `SubscriptionPosition` | The subscription position. |
 
-This section lists CRD configurations that are common for Pulsar functions, sources, sinks, and Function Mesh.
-
 ## Images
 
 This section describes image options available for Pulsar Function, source, sink and Function Mesh CRDs.
@@ -85,9 +83,9 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret. 
+In Function Mesh, the secret is defined through a `secretsMap`. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. 
 
-To use a secret in an environment variable in a Pod, follow these steps.
+To use a secret as an environment variable in a Pod, follow these steps.
 
 1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
 2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.

--- a/versioned_docs/version-0.1.5/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.1.5/connectors/io-crd-config/sink-crd-config.md
@@ -60,32 +60,24 @@ When you specify a function or connector, you can optionally specify how much of
 
 If the node where a Pod is running has enough of a resource available, it is possible (and allowed) for a Pod to use more resources than its `request` for that resource. However, a Pod is not allowed to use more than its resource `limit`.
 
-## Secrets
+## Authentication
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret.
-
-To use a secret in an environment variable in a Pod, follow these steps.
-
-1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
-2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.
-3. Modify your image and or command line so that the program looks for values in the specified environment variables.
-
-Pulsar clusters support using TLS or other authentication plugin for authentication.
+Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
     | Field | Description |
     | --- | --- |
-    | tlsAllowInsecureConnection | Allow insecure TLS connection. |
-    | tlsHostnameVerificationEnable | Enable hostname verification. |
-    | tlsTrustCertsFilePath | The path of the TLS trust certificate file. |
+    | `tlsAllowInsecureConnection` | Allow insecure TLS connection. |
+    | `tlsHostnameVerificationEnable` | Enable hostname verification. |
+    | `tlsTrustCertsFilePath` | The path of the TLS trust certificate file. |
 
-- Auth Secret
+- Authentication Secret
 
     | Field | Description |
     | --- | --- |
-    | clientAuthenticationPlugin | Client authentication plugin. |
-    | clientAuthenticationParameters | Client authentication parameters. |
+    | `clientAuthenticationPlugin` | The client authentication plugin. |
+    | `clientAuthenticationParameters` | The client authentication parameters. |
 
 ## Packages
 

--- a/versioned_docs/version-0.1.5/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.1.5/connectors/io-crd-config/source-crd-config.md
@@ -52,32 +52,24 @@ When you specify a function or connector, you can optionally specify how much of
 
 If the node where a Pod is running has enough of a resource available, it's possible (and allowed) for a Pod to use more resources than its `request` for that resource. However, a Pod is not allowed to use more than its resource `limit`.
 
-## Secrets
+## Authentication
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret.
-
-To use a secret in an environment variable in a Pod, follow these steps.
-
-1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
-2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.
-3. Modify your image and/or command line so that the program looks for values in the specified environment variables.
-
-Pulsar clusters support using TLS or other authentication plugin for authentication.
+Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
     | Field | Description |
     | --- | --- |
-    | tlsAllowInsecureConnection | Allow insecure TLS connection. |
-    | tlsHostnameVerificationEnable | Enable hostname verification. |
-    | tlsTrustCertsFilePath | The path of the TLS trust certificate file. |
+    | `tlsAllowInsecureConnection` | Allow insecure TLS connection. |
+    | `tlsHostnameVerificationEnable` | Enable hostname verification. |
+    | `tlsTrustCertsFilePath` | The path of the TLS trust certificate file. |
 
-- Auth Secret
+- Authentication Secret
 
     | Field | Description |
     | --- | --- |
-    | clientAuthenticationPlugin | Client authentication plugin. |
-    | clientAuthenticationParameters | Client authentication parameters. |
+    | `clientAuthenticationPlugin` | The client authentication plugin. |
+    | `clientAuthenticationParameters` | The client authentication parameters. |
 
 ## Packages
 

--- a/versioned_docs/version-0.1.5/functions/function-crd.md
+++ b/versioned_docs/version-0.1.5/functions/function-crd.md
@@ -32,8 +32,6 @@ This table lists Pulsar Function configurations.
 | `CleanupSubscription` | Configure whether to clean up subscriptions. |
 | `SubscriptionPosition` | The subscription position. |
 
-This section lists CRD configurations that are common for Pulsar functions, sources, sinks, and Function Mesh.
-
 ## Images
 
 This section describes image options available for Pulsar Function, source, sink and Function Mesh CRDs.
@@ -83,32 +81,24 @@ When you specify a function or connector, you can optionally specify how much of
 
 If the node where a Pod is running has enough of a resource available, it's possible (and allowed) for a pod to use more resources than its `request` for that resource specifies. However, a pod is not allowed to use more than its resource `limit`.
 
-## Secrets
+## Authentication
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret. 
-
-To use a secret in an environment variable in a Pod, follow these steps.
-
-1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
-2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.
-3. Modify your image and/or command line so that the program looks for values in the specified environment variables.
-
-Pulsar clusters supports using TLS or other authentication plugin for authentication.
+Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
     | Field | Description |
     | --- | --- |
-    | tlsAllowInsecureConnection | Allow insecure TLS connection. |
-    | tlsHostnameVerificationEnable | Enable hostname verification. |
-    | tlsTrustCertsFilePath | The path of the TLS trust certificate file. |
+    | `tlsAllowInsecureConnection` | Allow insecure TLS connection. |
+    | `tlsHostnameVerificationEnable` | Enable hostname verification. |
+    | `tlsTrustCertsFilePath` | The path of the TLS trust certificate file. |
 
-- Auth Secret
+- Authentication Secret
 
     | Field | Description |
     | --- | --- |
-    | clientAuthenticationPlugin | Client authentication plugin. |
-    | clientAuthenticationParameters | Client authentication parameters. |
+    | `clientAuthenticationPlugin` | The client authentication plugin. |
+    | `clientAuthenticationParameters` | The client authentication parameters. |
 
 ## Packages
 

--- a/versioned_docs/version-0.1.6/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.1.6/connectors/io-crd-config/sink-crd-config.md
@@ -60,32 +60,24 @@ When you specify a function or connector, you can optionally specify how much of
 
 If the node where a Pod is running has enough of a resource available, it is possible (and allowed) for a Pod to use more resources than its `request` for that resource. However, a Pod is not allowed to use more than its resource `limit`.
 
-## Secrets
+## Authentication
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret.
-
-To use a secret in an environment variable in a Pod, follow these steps.
-
-1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
-2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.
-3. Modify your image and or command line so that the program looks for values in the specified environment variables.
-
-Pulsar clusters support using TLS or other authentication plugin for authentication.
+Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
     | Field | Description |
     | --- | --- |
-    | tlsAllowInsecureConnection | Allow insecure TLS connection. |
-    | tlsHostnameVerificationEnable | Enable hostname verification. |
-    | tlsTrustCertsFilePath | The path of the TLS trust certificate file. |
+    | `tlsAllowInsecureConnection` | Allow insecure TLS connection. |
+    | `tlsHostnameVerificationEnable` | Enable hostname verification. |
+    | `tlsTrustCertsFilePath` | The path of the TLS trust certificate file. |
 
-- Auth Secret
+- Authentication Secret
 
     | Field | Description |
     | --- | --- |
-    | clientAuthenticationPlugin | Client authentication plugin. |
-    | clientAuthenticationParameters | Client authentication parameters. |
+    | `clientAuthenticationPlugin` | The client authentication plugin. |
+    | `clientAuthenticationParameters` | The client authentication parameters. |
 
 ## Packages
 

--- a/versioned_docs/version-0.1.6/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.1.6/connectors/io-crd-config/source-crd-config.md
@@ -52,32 +52,24 @@ When you specify a function or connector, you can optionally specify how much of
 
 If the node where a Pod is running has enough of a resource available, it's possible (and allowed) for a Pod to use more resources than its `request` for that resource. However, a Pod is not allowed to use more than its resource `limit`.
 
-## Secrets
+## Authentication
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret.
-
-To use a secret in an environment variable in a Pod, follow these steps.
-
-1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
-2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.
-3. Modify your image and/or command line so that the program looks for values in the specified environment variables.
-
-Pulsar clusters support using TLS or other authentication plugin for authentication.
+Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
     | Field | Description |
     | --- | --- |
-    | tlsAllowInsecureConnection | Allow insecure TLS connection. |
-    | tlsHostnameVerificationEnable | Enable hostname verification. |
-    | tlsTrustCertsFilePath | The path of the TLS trust certificate file. |
+    | `tlsAllowInsecureConnection` | Allow insecure TLS connection. |
+    | `tlsHostnameVerificationEnable` | Enable hostname verification. |
+    | `tlsTrustCertsFilePath` | The path of the TLS trust certificate file. |
 
-- Auth Secret
+- Authentication Secret
 
     | Field | Description |
     | --- | --- |
-    | clientAuthenticationPlugin | Client authentication plugin. |
-    | clientAuthenticationParameters | Client authentication parameters. |
+    | `clientAuthenticationPlugin` | The client authentication plugin. |
+    | `clientAuthenticationParameters` | The client authentication parameters. |
 
 ## Packages
 

--- a/versioned_docs/version-0.1.6/functions/function-crd.md
+++ b/versioned_docs/version-0.1.6/functions/function-crd.md
@@ -32,8 +32,6 @@ This table lists Pulsar Function configurations.
 | `CleanupSubscription` | Configure whether to clean up subscriptions. |
 | `SubscriptionPosition` | The subscription position. |
 
-This section lists CRD configurations that are common for Pulsar functions, sources, sinks, and Function Mesh.
-
 ## Images
 
 This section describes image options available for Pulsar Function, source, sink and Function Mesh CRDs.
@@ -83,32 +81,24 @@ When you specify a function or connector, you can optionally specify how much of
 
 If the node where a Pod is running has enough of a resource available, it's possible (and allowed) for a pod to use more resources than its `request` for that resource specifies. However, a pod is not allowed to use more than its resource `limit`.
 
-## Secrets
+## Authentication
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret. 
-
-To use a secret in an environment variable in a Pod, follow these steps.
-
-1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
-2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.
-3. Modify your image and/or command line so that the program looks for values in the specified environment variables.
-
-Pulsar clusters supports using TLS or other authentication plugin for authentication.
+Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
     | Field | Description |
     | --- | --- |
-    | tlsAllowInsecureConnection | Allow insecure TLS connection. |
-    | tlsHostnameVerificationEnable | Enable hostname verification. |
-    | tlsTrustCertsFilePath | The path of the TLS trust certificate file. |
+    | `tlsAllowInsecureConnection` | Allow insecure TLS connection. |
+    | `tlsHostnameVerificationEnable` | Enable hostname verification. |
+    | `tlsTrustCertsFilePath` | The path of the TLS trust certificate file. |
 
-- Auth Secret
+- Authentication Secret
 
     | Field | Description |
     | --- | --- |
-    | clientAuthenticationPlugin | Client authentication plugin. |
-    | clientAuthenticationParameters | Client authentication parameters. |
+    | `clientAuthenticationPlugin` | The client authentication plugin. |
+    | `clientAuthenticationParameters` | The client authentication parameters. |
 
 ## Packages
 

--- a/versioned_docs/version-0.1.7/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.1.7/connectors/io-crd-config/sink-crd-config.md
@@ -61,32 +61,24 @@ When you specify a function or connector, you can optionally specify how much of
 
 If the node where a Pod is running has enough of a resource available, it is possible (and allowed) for a Pod to use more resources than its `request` for that resource. However, a Pod is not allowed to use more than its resource `limit`.
 
-## Secrets
+## Authentication
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret.
-
-To use a secret in an environment variable in a Pod, follow these steps.
-
-1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
-2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.
-3. Modify your image and or command line so that the program looks for values in the specified environment variables.
-
-Pulsar clusters support using TLS or other authentication plugin for authentication.
+Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
     | Field | Description |
     | --- | --- |
-    | tlsAllowInsecureConnection | Allow insecure TLS connection. |
-    | tlsHostnameVerificationEnable | Enable hostname verification. |
-    | tlsTrustCertsFilePath | The path of the TLS trust certificate file. |
+    | `tlsAllowInsecureConnection` | Allow insecure TLS connection. |
+    | `tlsHostnameVerificationEnable` | Enable hostname verification. |
+    | `tlsTrustCertsFilePath` | The path of the TLS trust certificate file. |
 
-- Auth Secret
+- Authentication Secret
 
     | Field | Description |
     | --- | --- |
-    | clientAuthenticationPlugin | Client authentication plugin. |
-    | clientAuthenticationParameters | Client authentication parameters. |
+    | `clientAuthenticationPlugin` | The client authentication plugin. |
+    | `clientAuthenticationParameters` | The client authentication parameters. |
 
 ## Packages
 

--- a/versioned_docs/version-0.1.7/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.1.7/connectors/io-crd-config/source-crd-config.md
@@ -54,32 +54,24 @@ When you specify a function or connector, you can optionally specify how much of
 
 If the node where a Pod is running has enough of a resource available, it's possible (and allowed) for a Pod to use more resources than its `request` for that resource. However, a Pod is not allowed to use more than its resource `limit`.
 
-## Secrets
+## Authentication
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret.
-
-To use a secret in an environment variable in a Pod, follow these steps.
-
-1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
-2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.
-3. Modify your image and/or command line so that the program looks for values in the specified environment variables.
-
-Pulsar clusters support using TLS or other authentication plugin for authentication.
+Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
     | Field | Description |
     | --- | --- |
-    | tlsAllowInsecureConnection | Allow insecure TLS connection. |
-    | tlsHostnameVerificationEnable | Enable hostname verification. |
-    | tlsTrustCertsFilePath | The path of the TLS trust certificate file. |
+    | `tlsAllowInsecureConnection` | Allow insecure TLS connection. |
+    | `tlsHostnameVerificationEnable` | Enable hostname verification. |
+    | `tlsTrustCertsFilePath` | The path of the TLS trust certificate file. |
 
-- Auth Secret
+- Authentication Secret
 
     | Field | Description |
     | --- | --- |
-    | clientAuthenticationPlugin | Client authentication plugin. |
-    | clientAuthenticationParameters | Client authentication parameters. |
+    | `clientAuthenticationPlugin` | The client authentication plugin. |
+    | `clientAuthenticationParameters` | The client authentication parameters. |
 
 ## Packages
 

--- a/versioned_docs/version-0.1.7/functions/function-crd.md
+++ b/versioned_docs/version-0.1.7/functions/function-crd.md
@@ -33,8 +33,6 @@ This table lists Pulsar Function configurations.
 | `CleanupSubscription` | Configure whether to clean up subscriptions. |
 | `SubscriptionPosition` | The subscription position. |
 
-This section lists CRD configurations that are common for Pulsar functions, sources, sinks, and Function Mesh.
-
 ## Images
 
 This section describes image options available for Pulsar Function, source, sink and Function Mesh CRDs.
@@ -84,32 +82,24 @@ When you specify a function or connector, you can optionally specify how much of
 
 If the node where a Pod is running has enough of a resource available, it's possible (and allowed) for a pod to use more resources than its `request` for that resource specifies. However, a pod is not allowed to use more than its resource `limit`.
 
-## Secrets
+## Authentication
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret. 
-
-To use a secret in an environment variable in a Pod, follow these steps.
-
-1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
-2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.
-3. Modify your image and/or command line so that the program looks for values in the specified environment variables.
-
-Pulsar clusters supports using TLS or other authentication plugin for authentication.
+Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
     | Field | Description |
     | --- | --- |
-    | tlsAllowInsecureConnection | Allow insecure TLS connection. |
-    | tlsHostnameVerificationEnable | Enable hostname verification. |
-    | tlsTrustCertsFilePath | The path of the TLS trust certificate file. |
+    | `tlsAllowInsecureConnection` | Allow insecure TLS connection. |
+    | `tlsHostnameVerificationEnable` | Enable hostname verification. |
+    | `tlsTrustCertsFilePath` | The path of the TLS trust certificate file. |
 
-- Auth Secret
+- Authentication Secret
 
     | Field | Description |
     | --- | --- |
-    | clientAuthenticationPlugin | Client authentication plugin. |
-    | clientAuthenticationParameters | Client authentication parameters. |
+    | `clientAuthenticationPlugin` | The client authentication plugin. |
+    | `clientAuthenticationParameters` | The client authentication parameters. |
 
 ## Packages
 

--- a/versioned_docs/version-0.1.7/scaling.md
+++ b/versioned_docs/version-0.1.7/scaling.md
@@ -44,7 +44,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
-  This table lists built-in CPU-based autoscaling metrics. If these metrics cannot meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
+  This table lists built-in memory-based autoscaling metrics. If these metrics cannot meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
   
   | Option | Description |
   | --- | --- |

--- a/versioned_docs/version-0.1.7/scaling.md
+++ b/versioned_docs/version-0.1.7/scaling.md
@@ -34,7 +34,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 
 - CPU usage: auto-scale the number of Pods based on CPU utilization.
   
-  This table lists built-in CPU-based autoscaling metrics. If these metrics cannot meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
+  This table lists built-in CPU-based autoscaling metrics. If these metrics do not meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
   
   | Option | Description |
   | --- | --- |
@@ -44,7 +44,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
-  This table lists built-in memory-based autoscaling metrics. If these metrics cannot meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
+  This table lists built-in memory-based autoscaling metrics. If these metrics do not meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
   
   | Option | Description |
   | --- | --- |

--- a/versioned_docs/version-0.1.8/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.1.8/connectors/io-crd-config/sink-crd-config.md
@@ -61,32 +61,24 @@ When you specify a function or connector, you can optionally specify how much of
 
 If the node where a Pod is running has enough of a resource available, it is possible (and allowed) for a Pod to use more resources than its `request` for that resource. However, a Pod is not allowed to use more than its resource `limit`.
 
-## Secrets
+## Authentication
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret.
-
-To use a secret in an environment variable in a Pod, follow these steps.
-
-1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
-2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.
-3. Modify your image and or command line so that the program looks for values in the specified environment variables.
-
-Pulsar clusters support using TLS or other authentication plugin for authentication.
+Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
     | Field | Description |
     | --- | --- |
-    | tlsAllowInsecureConnection | Allow insecure TLS connection. |
-    | tlsHostnameVerificationEnable | Enable hostname verification. |
-    | tlsTrustCertsFilePath | The path of the TLS trust certificate file. |
+    | `tlsAllowInsecureConnection` | Allow insecure TLS connection. |
+    | `tlsHostnameVerificationEnable` | Enable hostname verification. |
+    | `tlsTrustCertsFilePath` | The path of the TLS trust certificate file. |
 
-- Auth Secret
+- Authentication Secret
 
     | Field | Description |
     | --- | --- |
-    | clientAuthenticationPlugin | Client authentication plugin. |
-    | clientAuthenticationParameters | Client authentication parameters. |
+    | `clientAuthenticationPlugin` | The client authentication plugin. |
+    | `clientAuthenticationParameters` | The client authentication parameters. |
 
 ## Packages
 

--- a/versioned_docs/version-0.1.8/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.1.8/connectors/io-crd-config/source-crd-config.md
@@ -54,32 +54,24 @@ When you specify a function or connector, you can optionally specify how much of
 
 If the node where a Pod is running has enough of a resource available, it's possible (and allowed) for a Pod to use more resources than its `request` for that resource. However, a Pod is not allowed to use more than its resource `limit`.
 
-## Secrets
+## Authentication
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret.
-
-To use a secret in an environment variable in a Pod, follow these steps.
-
-1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
-2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.
-3. Modify your image and/or command line so that the program looks for values in the specified environment variables.
-
-Pulsar clusters support using TLS or other authentication plugin for authentication.
+Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
     | Field | Description |
     | --- | --- |
-    | tlsAllowInsecureConnection | Allow insecure TLS connection. |
-    | tlsHostnameVerificationEnable | Enable hostname verification. |
-    | tlsTrustCertsFilePath | The path of the TLS trust certificate file. |
+    | `tlsAllowInsecureConnection` | Allow insecure TLS connection. |
+    | `tlsHostnameVerificationEnable` | Enable hostname verification. |
+    | `tlsTrustCertsFilePath` | The path of the TLS trust certificate file. |
 
-- Auth Secret
+- Authentication Secret
 
     | Field | Description |
     | --- | --- |
-    | clientAuthenticationPlugin | Client authentication plugin. |
-    | clientAuthenticationParameters | Client authentication parameters. |
+    | `clientAuthenticationPlugin` | The client authentication plugin. |
+    | `clientAuthenticationParameters` | The client authentication parameters. |
 
 ## Packages
 

--- a/versioned_docs/version-0.1.8/function-mesh-worker/deploy-mesh-worker.md
+++ b/versioned_docs/version-0.1.8/function-mesh-worker/deploy-mesh-worker.md
@@ -14,14 +14,14 @@ This document describes how to deploy the Function Mesh Worker service.
 > - You need to manually manage the [`ConfigMap`](/functions/function-crd.md#cluster-location), such as the Pulsar service URL.
 > - A Pulsar cluster with the Function Mesh Worker service should be the same Kubernetes cluster where the Function Mesh Operator is deployed.
 
-# Prerequisite
+## Prerequisite
 
 To deploy the Function Mesh Worker service, ensure that these services are already running in your environment.
 
 - Apache Pulsar cluster (v2.8.0 or higher version)
 - Function Mesh operator
 
-# Deploy Function Mesh Worker service with Pulsar brokers
+## Deploy Function Mesh Worker service with Pulsar brokers
 
 The following diagram illustrates how to deploy the Function Mesh Worker service along with Pulsar brokers.
 
@@ -29,7 +29,7 @@ The following diagram illustrates how to deploy the Function Mesh Worker service
 
 Function Mesh Worker service can forward requests to the Kubernetes cluster. After you start the Function Mesh Worker service, you can use the [`pulsar-admin`](https://pulsar.apache.org/docs/en/pulsar-admin/) CLI tool to manage Pulsar functions and connectors.
 
-## Configure the Function Mesh Worker service
+### Configure Function Mesh Worker service
 
 You can customize the Function Mesh Worker service using `functionsWorkerServiceCustomConfigs` in the `functions_worker.yml` manifest. This table lists available configurations.
 
@@ -49,7 +49,7 @@ You can customize the Function Mesh Worker service using `functionsWorkerService
 | `functionRunnerImages` | Map < String, String > | No | {} (empty string)| The runner image to run the Pulsar Function instances. |
 | `imagePullSecrets` | List < V1LocalObjectReference > | No | [] (empty string) | An optional list of references to secrets in the same namespace to pull images used by `PodSpec`. |
 
-## Start the Function Mesh Worker service
+### Start Function Mesh Worker service
 
 This section describes how to start the Function Mesh Worker service after you configure it.
 

--- a/versioned_docs/version-0.1.8/function-mesh-worker/function-mesh-worker-overview.md
+++ b/versioned_docs/version-0.1.8/function-mesh-worker/function-mesh-worker-overview.md
@@ -6,11 +6,11 @@ id: function-mesh-worker-overview
 
 This document gives a brief introduction into Function Mesh Worker service.
 
-# What is Function Mesh Worker service
+## What is Function Mesh Worker service
 
 Function Mesh Worker service is a plug-in for Pulsar. It is similar to Pulsar Function Worker service but uses Function Mesh operators to schedule and run functions. Function Mesh Worker service enables you to use the [`pulsar-admin`](https://pulsar.apache.org/docs/en/pulsar-admin/) or [`pulsarctl`](https://docs.streamnative.io/pulsarctl/v2.7.0.7/) CLI tools to manage Pulsar functions and connectors in Function Mesh.
 
-# How Function Mesh Worker service works
+## How Function Mesh Worker service works
 
 The following figure illustrates how Function Mesh Worker service works with Pulsar proxy, converts and forwards function and / or connector admin requests to the Kubernetes cluster. The benefit of this approach is that you do not need to change the way you create and submit functions and / or connectors.
 

--- a/versioned_docs/version-0.1.8/functions/function-crd.md
+++ b/versioned_docs/version-0.1.8/functions/function-crd.md
@@ -33,8 +33,6 @@ This table lists Pulsar Function configurations.
 | `CleanupSubscription` | Configure whether to clean up subscriptions. |
 | `SubscriptionPosition` | The subscription position. |
 
-This section lists CRD configurations that are common for Pulsar functions, sources, sinks, and Function Mesh.
-
 ## Images
 
 This section describes image options available for Pulsar Function, source, sink and Function Mesh CRDs.
@@ -84,32 +82,24 @@ When you specify a function or connector, you can optionally specify how much of
 
 If the node where a Pod is running has enough of a resource available, it's possible (and allowed) for a pod to use more resources than its `request` for that resource specifies. However, a pod is not allowed to use more than its resource `limit`.
 
-## Secrets
+## Authentication
 
-In Function Mesh, the secret is defined through a secretsMap. To use a secret, a Pod needs to reference the secret. Pods can consume secretsMaps as environment variables in a volume. You can specify the `data` field when creating a configuration file for a secret. 
-
-To use a secret in an environment variable in a Pod, follow these steps.
-
-1. Create a secret or use an existing one. Multiple Pods can reference the same secret.
-2. Modify your Pod definition in each container, which you want to consume the value of a secret key, to add an environment variable for each secret key that you want to consume.
-3. Modify your image and/or command line so that the program looks for values in the specified environment variables.
-
-Pulsar clusters supports using TLS or other authentication plugin for authentication.
+Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
     | Field | Description |
     | --- | --- |
-    | tlsAllowInsecureConnection | Allow insecure TLS connection. |
-    | tlsHostnameVerificationEnable | Enable hostname verification. |
-    | tlsTrustCertsFilePath | The path of the TLS trust certificate file. |
+    | `tlsAllowInsecureConnection` | Allow insecure TLS connection. |
+    | `tlsHostnameVerificationEnable` | Enable hostname verification. |
+    | `tlsTrustCertsFilePath` | The path of the TLS trust certificate file. |
 
-- Auth Secret
+- Authentication Secret
 
     | Field | Description |
     | --- | --- |
-    | clientAuthenticationPlugin | Client authentication plugin. |
-    | clientAuthenticationParameters | Client authentication parameters. |
+    | `clientAuthenticationPlugin` | The client authentication plugin. |
+    | `clientAuthenticationParameters` | The client authentication parameters. |
 
 ## Packages
 

--- a/versioned_docs/version-0.1.8/scaling.md
+++ b/versioned_docs/version-0.1.8/scaling.md
@@ -44,7 +44,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
-  This table lists built-in CPU-based autoscaling metrics. If these metrics cannot meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
+  This table lists built-in memory-based autoscaling metrics. If these metrics cannot meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
   
   | Option | Description |
   | --- | --- |

--- a/versioned_docs/version-0.1.8/scaling.md
+++ b/versioned_docs/version-0.1.8/scaling.md
@@ -34,7 +34,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 
 - CPU usage: auto-scale the number of Pods based on CPU utilization.
   
-  This table lists built-in CPU-based autoscaling metrics. If these metrics cannot meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
+  This table lists built-in CPU-based autoscaling metrics. If these metrics do not meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
   
   | Option | Description |
   | --- | --- |
@@ -44,7 +44,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
-  This table lists built-in memory-based autoscaling metrics. If these metrics cannot meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
+  This table lists built-in memory-based autoscaling metrics. If these metrics do not meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
   
   | Option | Description |
   | --- | --- |


### PR DESCRIPTION
### Motivation
In Function Mesh V0.1.9 release, [secrets are supported](https://github.com/streamnative/function-mesh-worker-service/pull/21). Therefore, update docs for this code PR.

### Modifications:
- Update docs for secrets supported on function mesh worker service.
  - Related release: latest
- Refine authentication descriptions 
  - Related releases: v0.1.5- latest
- Update typos, code format and heading levels:
  - Related releases: all releases
