### PR TITLE
[v0.1.11]--Update Function mesh worker version matrix table

### DIFF
--- a/docs/function-mesh-worker/function-mesh-worker-overview.md
+++ b/docs/function-mesh-worker/function-mesh-worker-overview.md
@@ -22,4 +22,6 @@ This table lists the version mapping relationships between Function Mesh and Fun
 
 | Function Mesh | Function Mesh Worker service |
 | --- | --- |
-| v0.1.9 | <br />- v2.9.1 .x (v2.9.1.1-v2.9.1.2) <br />- v2.8.2.x (v2.8.2.0- v2.8.2.1 v2.8.2.2) <br />- v2.8.1 x (2.8.1.25-v2.8.1.26, v.2.8.1.28-v2.8.1.30)|
+| v0.1.9 | <br />- v2.9.1.x (v2.9.1.1-v2.9.1.2) <br />- v2.8.2.x (v2.8.2.0-v2.8.2.2) <br />- v2.8.1 x (2.8.1.25-v2.8.1.26, v.2.8.1.28-v2.8.1.30)|
+| v0.1.10| <br />- v2.10.0+ <br />- v2.9.2.1+ <br />- v2.8.2.3+ |
+| v0.1.11| <br />- v2.10.0+ <br />- v2.9.2.13+ <br />- v2.8.2.14+ |

--- a/docs/install-function-mesh.md
+++ b/docs/install-function-mesh.md
@@ -66,6 +66,20 @@ This example shows how to install Function Mesh through [Helm](https://helm.sh/)
 
    2. Install Function Mesh Operator.
 
+        There are some parameters for the Function Mesh Operator, and you can customize them for a particular purpose. 
+        This table outlines the configurable parameters of the Function Mesh Operator and their default values.
+        | Parameters | Description | Default|
+        |--         |--           |--       |
+        |`enable-leader-election`| Whether the Function Mesh Controller Manager should enable leader election. | true|
+        | `enable-pprof` |Whether the Function Mesh Controller Manager controller-manager should enable [pprof](https://github.com/google/pprof). | false|
+        |`pprof-addr`|The address of the pprof. |:8090|
+        | `metrics-addr`| The address of the metrics. |:8080|
+        | `health-probe-addr`|The address of the health probe. |:8000|
+        |`config-file`| The config file of the Function Mesh Controller Manager. |/etc/config/config.yaml|
+        
+
+        For example, if you want to enable `pprof` for the Function Mesh Operator, set the `pprof.enable` to `true` in the `values.yaml` file.
+
         ```shell
         helm install function-mesh --values charts/function-mesh-operator/values.yaml charts/function-mesh-operator --namespace=function-mesh
         ```

--- a/versioned_docs/version-0.1.10/function-mesh-worker/function-mesh-worker-overview.md
+++ b/versioned_docs/version-0.1.10/function-mesh-worker/function-mesh-worker-overview.md
@@ -22,4 +22,5 @@ This table lists the version mapping relationships between Function Mesh and Fun
 
 | Function Mesh | Function Mesh Worker service |
 | --- | --- |
-| v0.1.9 | <br />- v2.9.1 .x (v2.9.1.1-v2.9.1.2) <br />- v2.8.2.x (v2.8.2.0- v2.8.2.1 v2.8.2.2) <br />- v2.8.1 x (2.8.1.25-v2.8.1.26, v.2.8.1.28-v2.8.1.30)|
+| v0.1.9 | <br />- v2.9.1.x (v2.9.1.1-v2.9.1.2) <br />- v2.8.2.x (v2.8.2.0-v2.8.2.2) <br />- v2.8.1 x (2.8.1.25-v2.8.1.26, v.2.8.1.28-v2.8.1.30)|
+| v0.1.10| <br />- v2.10.0+ <br />- v2.9.2.0+ <br />- v2.8.2.3+ |

--- a/versioned_docs/version-0.1.9/function-mesh-worker/function-mesh-worker-overview.md
+++ b/versioned_docs/version-0.1.9/function-mesh-worker/function-mesh-worker-overview.md
@@ -22,4 +22,4 @@ This table lists the version mapping relationships between Function Mesh and Fun
 
 | Function Mesh | Function Mesh Worker service |
 | --- | --- |
-| v0.1.9 | <br />- v2.9.1 .x (v2.9.1.1-v2.9.1.2) <br />- v2.8.2.x (v2.8.2.0- v2.8.2.1 v2.8.2.2) <br />- v2.8.1 x (2.8.1.25-v2.8.1.26, v.2.8.1.28-v2.8.1.30)|
+| v0.1.9 | <br />- v2.9.1.x (v2.9.1.1-v2.9.1.2) <br />- v2.8.2.x (v2.8.2.0-v2.8.2.2) <br />- v2.8.1 x (2.8.1.25-v2.8.1.26, v.2.8.1.28-v2.8.1.30)|


### PR DESCRIPTION
### Motivation
Add doc for [PR--verify function mesh v0.1.11-rc3](https://github.com/streamnative/function-mesh-worker-service/pull/141) 

### Modification

- Update the matrix table between Function Mesh v0.1.11 & Function Mesh worker service versions
- Update the matrix table between Function Mesh v0.1.10 & Function Mesh worker service versions
- Fix typo in Function Mesh v0.1.9 release