### PR TITLE
[v0.1.11]--Add function mesh worker service config

### DIFF
--- a/docs/function-mesh-worker/deploy-mesh-worker.md
+++ b/docs/function-mesh-worker/deploy-mesh-worker.md
@@ -48,6 +48,14 @@ You can customize the Function Mesh Worker service using `functionsWorkerService
 | `imagePullPolicy` | string | No | "IfNotPresent" | The image pull policy for images to run Pulsar Function instances. By default, it is set to `IfNotPresent`. |
 | `functionRunnerImages` | Map < String, String > | No | {} (empty string)| The runner image to run the Pulsar Function instances. |
 | `imagePullSecrets` | List< V1LocalObjectReference > | No | [] (empty string) | An optional list of references to secrets in the same namespace to pull images used by `PodSpec`. |
+| `labels` | Map < String, String > | No | {} (empty string) | Specify the labels being attached to a Pod that is created by the Function Mesh Operator for the cluster. |
+| `functionLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attach to a Function's Pod. When both `functionLabels` and `labels` are specified, `functionLabels` overrides `labels`. |
+| `sinkLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attach to a Sink's Pod. When both `sinkLabels` and `labels` are specified, `sinkLabels` overrides `labels`. |
+| `sourceLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attach to a Source's Pod. When both `sourceLabels` and `labels` are specified, `sourceLabels` overrides `labels`. |
+| `annotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attached to a Pod that is created by the Function Mesh Operator for the cluster. |
+| `functionAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Function's Pod. When both `functionAnnotations` and `annotations` are specified, `functionAnnotations` overrides `annotations`. |
+| `sinkAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Sink's Pod. When both `sinkAnnotations` and `annotations` are specified, `sinkAnnotations` overrides `annotations`. |
+| `sourceAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Source's Pod. When both `sourceAnnotations` and `annotations` are specified, `sourceAnnotations` overrides `annotations`. |
 
 ### Start Function Mesh Worker service
 

--- a/docs/function-mesh-worker/deploy-mesh-worker.md
+++ b/docs/function-mesh-worker/deploy-mesh-worker.md
@@ -55,7 +55,7 @@ You can customize the Function Mesh Worker service using `functionsWorkerService
 | `annotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attached to a Pod that is created by the Function Mesh Operator for the cluster. |
 | `functionAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attached to a Function's Pod. When both `functionAnnotations` and `annotations` are specified, `functionAnnotations` overrides `annotations`. |
 | `sinkAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attached to a Sink's Pod. When both `sinkAnnotations` and `annotations` are specified, `sinkAnnotations` overrides `annotations`. |
-| `sourceAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Source's Pod. When both `sourceAnnotations` and `annotations` are specified, `sourceAnnotations` overrides `annotations`. |
+| `sourceAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attached to a Source's Pod. When both `sourceAnnotations` and `annotations` are specified, `sourceAnnotations` overrides `annotations`. |
 
 ### Start Function Mesh Worker service
 

--- a/docs/function-mesh-worker/deploy-mesh-worker.md
+++ b/docs/function-mesh-worker/deploy-mesh-worker.md
@@ -53,7 +53,7 @@ You can customize the Function Mesh Worker service using `functionsWorkerService
 | `sinkLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attached to a Sink's Pod. When both `sinkLabels` and `labels` are specified, `sinkLabels` overrides `labels`. |
 | `sourceLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attached to a Source's Pod. When both `sourceLabels` and `labels` are specified, `sourceLabels` overrides `labels`. |
 | `annotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attached to a Pod that is created by the Function Mesh Operator for the cluster. |
-| `functionAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Function's Pod. When both `functionAnnotations` and `annotations` are specified, `functionAnnotations` overrides `annotations`. |
+| `functionAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attached to a Function's Pod. When both `functionAnnotations` and `annotations` are specified, `functionAnnotations` overrides `annotations`. |
 | `sinkAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Sink's Pod. When both `sinkAnnotations` and `annotations` are specified, `sinkAnnotations` overrides `annotations`. |
 | `sourceAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Source's Pod. When both `sourceAnnotations` and `annotations` are specified, `sourceAnnotations` overrides `annotations`. |
 

--- a/docs/function-mesh-worker/deploy-mesh-worker.md
+++ b/docs/function-mesh-worker/deploy-mesh-worker.md
@@ -54,7 +54,7 @@ You can customize the Function Mesh Worker service using `functionsWorkerService
 | `sourceLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attached to a Source's Pod. When both `sourceLabels` and `labels` are specified, `sourceLabels` overrides `labels`. |
 | `annotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attached to a Pod that is created by the Function Mesh Operator for the cluster. |
 | `functionAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attached to a Function's Pod. When both `functionAnnotations` and `annotations` are specified, `functionAnnotations` overrides `annotations`. |
-| `sinkAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Sink's Pod. When both `sinkAnnotations` and `annotations` are specified, `sinkAnnotations` overrides `annotations`. |
+| `sinkAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attached to a Sink's Pod. When both `sinkAnnotations` and `annotations` are specified, `sinkAnnotations` overrides `annotations`. |
 | `sourceAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Source's Pod. When both `sourceAnnotations` and `annotations` are specified, `sourceAnnotations` overrides `annotations`. |
 
 ### Start Function Mesh Worker service

--- a/docs/function-mesh-worker/deploy-mesh-worker.md
+++ b/docs/function-mesh-worker/deploy-mesh-worker.md
@@ -51,7 +51,7 @@ You can customize the Function Mesh Worker service using `functionsWorkerService
 | `labels` | Map < String, String > | No | {} (empty string) | Specify the labels being attached to a Pod that is created by the Function Mesh Operator for the cluster. |
 | `functionLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attached to a Function's Pod. When both `functionLabels` and `labels` are specified, `functionLabels` overrides `labels`. |
 | `sinkLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attached to a Sink's Pod. When both `sinkLabels` and `labels` are specified, `sinkLabels` overrides `labels`. |
-| `sourceLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attach to a Source's Pod. When both `sourceLabels` and `labels` are specified, `sourceLabels` overrides `labels`. |
+| `sourceLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attached to a Source's Pod. When both `sourceLabels` and `labels` are specified, `sourceLabels` overrides `labels`. |
 | `annotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attached to a Pod that is created by the Function Mesh Operator for the cluster. |
 | `functionAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Function's Pod. When both `functionAnnotations` and `annotations` are specified, `functionAnnotations` overrides `annotations`. |
 | `sinkAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Sink's Pod. When both `sinkAnnotations` and `annotations` are specified, `sinkAnnotations` overrides `annotations`. |

--- a/docs/function-mesh-worker/deploy-mesh-worker.md
+++ b/docs/function-mesh-worker/deploy-mesh-worker.md
@@ -49,7 +49,7 @@ You can customize the Function Mesh Worker service using `functionsWorkerService
 | `functionRunnerImages` | Map < String, String > | No | {} (empty string)| The runner image to run the Pulsar Function instances. |
 | `imagePullSecrets` | List< V1LocalObjectReference > | No | [] (empty string) | An optional list of references to secrets in the same namespace to pull images used by `PodSpec`. |
 | `labels` | Map < String, String > | No | {} (empty string) | Specify the labels being attached to a Pod that is created by the Function Mesh Operator for the cluster. |
-| `functionLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attach to a Function's Pod. When both `functionLabels` and `labels` are specified, `functionLabels` overrides `labels`. |
+| `functionLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attached to a Function's Pod. When both `functionLabels` and `labels` are specified, `functionLabels` overrides `labels`. |
 | `sinkLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attach to a Sink's Pod. When both `sinkLabels` and `labels` are specified, `sinkLabels` overrides `labels`. |
 | `sourceLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attach to a Source's Pod. When both `sourceLabels` and `labels` are specified, `sourceLabels` overrides `labels`. |
 | `annotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attached to a Pod that is created by the Function Mesh Operator for the cluster. |

--- a/docs/function-mesh-worker/deploy-mesh-worker.md
+++ b/docs/function-mesh-worker/deploy-mesh-worker.md
@@ -50,7 +50,7 @@ You can customize the Function Mesh Worker service using `functionsWorkerService
 | `imagePullSecrets` | List< V1LocalObjectReference > | No | [] (empty string) | An optional list of references to secrets in the same namespace to pull images used by `PodSpec`. |
 | `labels` | Map < String, String > | No | {} (empty string) | Specify the labels being attached to a Pod that is created by the Function Mesh Operator for the cluster. |
 | `functionLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attached to a Function's Pod. When both `functionLabels` and `labels` are specified, `functionLabels` overrides `labels`. |
-| `sinkLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attach to a Sink's Pod. When both `sinkLabels` and `labels` are specified, `sinkLabels` overrides `labels`. |
+| `sinkLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attached to a Sink's Pod. When both `sinkLabels` and `labels` are specified, `sinkLabels` overrides `labels`. |
 | `sourceLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attach to a Source's Pod. When both `sourceLabels` and `labels` are specified, `sourceLabels` overrides `labels`. |
 | `annotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attached to a Pod that is created by the Function Mesh Operator for the cluster. |
 | `functionAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Function's Pod. When both `functionAnnotations` and `annotations` are specified, `functionAnnotations` overrides `annotations`. |

--- a/versioned_docs/version-0.1.10/function-mesh-worker/deploy-mesh-worker.md
+++ b/versioned_docs/version-0.1.10/function-mesh-worker/deploy-mesh-worker.md
@@ -48,6 +48,14 @@ You can customize the Function Mesh Worker service using `functionsWorkerService
 | `imagePullPolicy` | string | No | "IfNotPresent" | The image pull policy for images to run Pulsar Function instances. By default, it is set to `IfNotPresent`. |
 | `functionRunnerImages` | Map < String, String > | No | {} (empty string)| The runner image to run the Pulsar Function instances. |
 | `imagePullSecrets` | List< V1LocalObjectReference > | No | [] (empty string) | An optional list of references to secrets in the same namespace to pull images used by `PodSpec`. |
+| `labels` | Map < String, String > | No | {} (empty string) | Specify the labels being attached to a Pod that is created by the Function Mesh Operator for the cluster. |
+| `functionLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attach to a Function's Pod. When both `functionLabels` and `labels` are specified, `functionLabels` overrides `labels`. |
+| `sinkLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attach to a Sink's Pod. When both `sinkLabels` and `labels` are specified, `sinkLabels` overrides `labels`. |
+| `sourceLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attach to a Source's Pod. When both `sourceLabels` and `labels` are specified, `sourceLabels` overrides `labels`. |
+| `annotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attached to a Pod that is created by the Function Mesh Operator for the cluster. |
+| `functionAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Function's Pod. When both `functionAnnotations` and `annotations` are specified, `functionAnnotations` overrides `annotations`. |
+| `sinkAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Sink's Pod. When both `sinkAnnotations` and `annotations` are specified, `sinkAnnotations` overrides `annotations`. |
+| `sourceAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Source's Pod. When both `sourceAnnotations` and `annotations` are specified, `sourceAnnotations` overrides `annotations`. |
 
 ### Start Function Mesh Worker service
 

--- a/versioned_docs/version-0.1.10/function-mesh-worker/deploy-mesh-worker.md
+++ b/versioned_docs/version-0.1.10/function-mesh-worker/deploy-mesh-worker.md
@@ -48,14 +48,6 @@ You can customize the Function Mesh Worker service using `functionsWorkerService
 | `imagePullPolicy` | string | No | "IfNotPresent" | The image pull policy for images to run Pulsar Function instances. By default, it is set to `IfNotPresent`. |
 | `functionRunnerImages` | Map < String, String > | No | {} (empty string)| The runner image to run the Pulsar Function instances. |
 | `imagePullSecrets` | List< V1LocalObjectReference > | No | [] (empty string) | An optional list of references to secrets in the same namespace to pull images used by `PodSpec`. |
-| `labels` | Map < String, String > | No | {} (empty string) | Specify the labels being attached to a Pod that is created by the Function Mesh Operator for the cluster. |
-| `functionLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attach to a Function's Pod. When both `functionLabels` and `labels` are specified, `functionLabels` overrides `labels`. |
-| `sinkLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attach to a Sink's Pod. When both `sinkLabels` and `labels` are specified, `sinkLabels` overrides `labels`. |
-| `sourceLabels` | Map < String, String > | No | {} (empty string) | Specify the labels being attach to a Source's Pod. When both `sourceLabels` and `labels` are specified, `sourceLabels` overrides `labels`. |
-| `annotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attached to a Pod that is created by the Function Mesh Operator for the cluster. |
-| `functionAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Function's Pod. When both `functionAnnotations` and `annotations` are specified, `functionAnnotations` overrides `annotations`. |
-| `sinkAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Sink's Pod. When both `sinkAnnotations` and `annotations` are specified, `sinkAnnotations` overrides `annotations`. |
-| `sourceAnnotations` | Map < String, String > | No | {} (empty string) | Specify the annotations being attach to a Source's Pod. When both `sourceAnnotations` and `annotations` are specified, `sourceAnnotations` overrides `annotations`. |
 
 ### Start Function Mesh Worker service
 


### PR DESCRIPTION
### Motivation

This PR is to update docs for [code PR --support custom labels and annotations in custom config](https://github.com/streamnative/function-mesh-worker-service/pull/84).

### Modification
- Update Function Mesh Worker service config
