### PR TITLE
[v0.1.11]--Update Function Mesh Operator config and supported k8s versions

### DIFF
--- a/docs/install-function-mesh.md
+++ b/docs/install-function-mesh.md
@@ -14,7 +14,7 @@ This section describes how to install Function Mesh through the `install.sh` scr
 
 Before installing Function Mesh, ensure to perform the following operations.
 
-- Kubernetes server 1.12 or higher.
+- Kubernetes server v1.17 or higher.
 - Create and connect to a [Kubernetes cluster](https://kubernetes.io/).
 - Create a [Pulsar cluster](https://pulsar.apache.org/docs/en/kubernetes-helm/) in the Kubernetes cluster.
 - Deploy [Pulsar Functions](https://pulsar.apache.org/docs/en/functions-overview/).
@@ -66,8 +66,8 @@ This example shows how to install Function Mesh through [Helm](https://helm.sh/)
 
    2. Install Function Mesh Operator.
 
-        There are some parameters for the Function Mesh Operator, and you can customize them for a particular purpose. 
         This table outlines the configurable parameters of the Function Mesh Operator and their default values.
+
         | Parameters | Description | Default|
         |--         |--           |--       |
         |`enable-leader-election`| Whether the Function Mesh Controller Manager should enable leader election. | true|
@@ -75,7 +75,7 @@ This example shows how to install Function Mesh through [Helm](https://helm.sh/)
         |`pprof-addr`|The address of the pprof. |:8090|
         | `metrics-addr`| The address of the metrics. |:8080|
         | `health-probe-addr`|The address of the health probe. |:8000|
-        |`config-file`| The config file of the Function Mesh Controller Manager. |/etc/config/config.yaml|
+        |`config-file`| The configuration file of the Function Mesh Controller Manager, which includes `runnerImages`, `resourceLabels`, and `resourceAnnotations` configurations. <br />- `runnerImage`: the runner image to run the Pulsar Function instances. Currently, it supports Java, Python, and Go runner images. <br />- `resourceLabels`: set labels for Pulsar Functions, Sources, or Sinks. <br />- `resourceAnnotations`: set annotations for Pulsar Functions, Sources, or Sinks.  |/etc/config/config.yaml|
         
 
         For example, if you want to enable `pprof` for the Function Mesh Operator, set the `pprof.enable` to `true` in the `values.yaml` file.

--- a/docs/install-function-mesh.md
+++ b/docs/install-function-mesh.md
@@ -71,7 +71,7 @@ This example shows how to install Function Mesh through [Helm](https://helm.sh/)
         | Parameters | Description | Default|
         |--         |--           |--       |
         |`enable-leader-election`| Whether the Function Mesh Controller Manager should enable leader election. | true|
-        | `enable-pprof` |Whether the Function Mesh Controller Manager controller-manager should enable [pprof](https://github.com/google/pprof). | false|
+        | `enable-pprof` |Whether the Function Mesh Controller Manager should enable [pprof](https://github.com/google/pprof). | false|
         |`pprof-addr`|The address of the pprof. |:8090|
         | `metrics-addr`| The address of the metrics. |:8080|
         | `health-probe-addr`|The address of the health probe. |:8000|

--- a/docs/install-function-mesh.md
+++ b/docs/install-function-mesh.md
@@ -69,14 +69,13 @@ This example shows how to install Function Mesh through [Helm](https://helm.sh/)
         This table outlines the configurable parameters of the Function Mesh Operator and their default values.
 
         | Parameters | Description | Default|
-        |--         |--           |--       |
+        | --- | --- | --- |
         |`enable-leader-election`| Whether the Function Mesh Controller Manager should enable leader election. | true|
-        | `enable-pprof` |Whether the Function Mesh Controller Manager should enable [pprof](https://github.com/google/pprof). | false|
-        |`pprof-addr`|The address of the pprof. |:8090|
-        | `metrics-addr`| The address of the metrics. |:8080|
-        | `health-probe-addr`|The address of the health probe. |:8000|
-        |`config-file`| The configuration file of the Function Mesh Controller Manager, which includes `runnerImages`, `resourceLabels`, and `resourceAnnotations` configurations. <br />- `runnerImage`: the runner image to run the Pulsar Function instances. Currently, it supports Java, Python, and Go runner images. <br />- `resourceLabels`: set labels for Pulsar Functions, Sources, or Sinks. <br />- `resourceAnnotations`: set annotations for Pulsar Functions, Sources, or Sinks.  |/etc/config/config.yaml|
-        
+        | `enable-pprof` |Whether the Function Mesh Controller Manager should enable [pprof](https://github.com/google/pprof). | `false`|
+        |`pprof-addr`|The address of the pprof. |`:8090`|
+        | `metrics-addr`| The address of the metrics. |`:8080`|
+        | `health-probe-addr`|The address of the health probe. |`:8000`|
+        |`config-file`| The configuration file of the Function Mesh Controller Manager, which includes `runnerImages`, `resourceLabels`, and `resourceAnnotations` configurations. <br />- `runnerImage`: the runner image to run the Pulsar Function instances. Currently, it supports Java, Python, and Go runner images. <br />- `resourceLabels`: set labels for Pulsar Functions, Sources, or Sinks. <br />- `resourceAnnotations`: set annotations for Pulsar Functions, Sources, or Sinks.  |`/etc/config/configs.yaml`|
 
         For example, if you want to enable `pprof` for the Function Mesh Operator, set the `pprof.enable` to `true` in the `values.yaml` file.
 

--- a/docs/overview/overview.md
+++ b/docs/overview/overview.md
@@ -147,6 +147,9 @@ Figure 7. The Function Mesh architecture
   - [Function Mesh overview](/function-mesh/function-mesh-overview.md)
   - [Function Mesh CRD configurations](/function-mesh/function-mesh-crd.md)
   - [Run Function Mesh](/function-mesh/run-function-mesh.md)
+- Function Mesh Worker
+  - [Function Mesh Worker service overview](/function-mesh-worker/function-mesh-worker-overview.md)
+  - [Deploy Function Mesh Worker service](/function-mesh-worker/deploy-mesh-worker.md)
 - [Scaling](/scaling.md)
 - Migration
   - [Migrate Pulsar Functions](/migration/migrate-function.md)

--- a/versioned_docs/version-0.1.10/install-function-mesh.md
+++ b/versioned_docs/version-0.1.10/install-function-mesh.md
@@ -14,7 +14,7 @@ This section describes how to install Function Mesh through the `install.sh` scr
 
 Before installing Function Mesh, ensure to perform the following operations.
 
-- Kubernetes server 1.12 or higher.
+- Kubernetes server v1.16 - v1.21.
 - Create and connect to a [Kubernetes cluster](https://kubernetes.io/).
 - Create a [Pulsar cluster](https://pulsar.apache.org/docs/en/kubernetes-helm/) in the Kubernetes cluster.
 - Deploy [Pulsar Functions](https://pulsar.apache.org/docs/en/functions-overview/).

--- a/versioned_docs/version-0.1.10/overview/overview.md
+++ b/versioned_docs/version-0.1.10/overview/overview.md
@@ -147,6 +147,9 @@ Figure 7. The Function Mesh architecture
   - [Function Mesh overview](/function-mesh/function-mesh-overview.md)
   - [Function Mesh CRD configurations](/function-mesh/function-mesh-crd.md)
   - [Run Function Mesh](/function-mesh/run-function-mesh.md)
+- Function Mesh Worker
+  - [Function Mesh Worker service overview](/function-mesh-worker/function-mesh-worker-overview.md)
+  - [Deploy Function Mesh Worker service](/function-mesh-worker/deploy-mesh-worker.md)
 - [Scaling](/scaling.md)
 - Migration
   - [Migrate Pulsar Functions](/migration/migrate-function.md)

--- a/versioned_docs/version-0.1.8/overview/overview.md
+++ b/versioned_docs/version-0.1.8/overview/overview.md
@@ -147,6 +147,9 @@ Figure 7. The Function Mesh architecture
   - [Function Mesh overview](/function-mesh/function-mesh-overview.md)
   - [Function Mesh CRD configurations](/function-mesh/function-mesh-crd.md)
   - [Run Function Mesh](/function-mesh/run-function-mesh.md)
+- Function Mesh Worker
+  - [Function Mesh Worker service overview](/function-mesh-worker/function-mesh-worker-overview.md)
+  - [Deploy Function Mesh Worker service](/function-mesh-worker/deploy-mesh-worker.md)
 - [Scaling](/scaling.md)
 - Migration
   - [Migrate Pulsar Functions](/migration/migrate-function.md)

--- a/versioned_docs/version-0.1.9/install-function-mesh.md
+++ b/versioned_docs/version-0.1.9/install-function-mesh.md
@@ -14,7 +14,7 @@ This section describes how to install Function Mesh through the `install.sh` scr
 
 Before installing Function Mesh, ensure to perform the following operations.
 
-- Kubernetes server 1.12 or higher.
+- Kubernetes server v1.16 - v1.21.
 - Create and connect to a [Kubernetes cluster](https://kubernetes.io/).
 - Create a [Pulsar cluster](https://pulsar.apache.org/docs/en/kubernetes-helm/) in the Kubernetes cluster.
 - Deploy [Pulsar Functions](https://pulsar.apache.org/docs/en/functions-overview/).

--- a/versioned_docs/version-0.1.9/overview/overview.md
+++ b/versioned_docs/version-0.1.9/overview/overview.md
@@ -147,6 +147,9 @@ Figure 7. The Function Mesh architecture
   - [Function Mesh overview](/function-mesh/function-mesh-overview.md)
   - [Function Mesh CRD configurations](/function-mesh/function-mesh-crd.md)
   - [Run Function Mesh](/function-mesh/run-function-mesh.md)
+- Function Mesh Worker
+  - [Function Mesh Worker service overview](/function-mesh-worker/function-mesh-worker-overview.md)
+  - [Deploy Function Mesh Worker service](/function-mesh-worker/deploy-mesh-worker.md)
 - [Scaling](/scaling.md)
 - Migration
   - [Migrate Pulsar Functions](/migration/migrate-function.md)


### PR DESCRIPTION
### Motivation
This PR is to updated docs for the following code PRs, as well as update some legacy doc issues.

- [ISSUE 315] Move apiextensions.k8s.io/v1beta1 to apiextensions.k8s.io/v1 ([ref](https://github.com/streamnative/function-mesh/pull/328))
- add controller-configs ([ref](https://github.com/streamnative/function-mesh/pull/322))
### Modification
- Update installation doc (update docs for two code PRs)
  - Affected releases: v0.1.9 - v0.1.11)
- Update overview doc (fix legacy doc issue)
  - Affected releases: v0.1.8 - v0.1.11)
