### PR TITLE
Update heading levels for release notes

### DIFF
--- a/docs/releases/release-note-0-1-7.md
+++ b/docs/releases/release-note-0-1-7.md
@@ -6,7 +6,7 @@ id: release-note-0-1-7
 
 Here are some highlights of this release. For a full list of updates available for Release v0.1.7, check out [here](https://github.com/streamnative/function-mesh/releases/tag/v0.1.7).
 
-# YAML configuration supports multiple values
+## YAML configuration supports multiple values
 
 In previous releases, the Pulsar Function or connector configurations were declared as `map[string]string`, and nested or complex configurations shown below were not supported.
 
@@ -59,13 +59,13 @@ sinkConfig:
       use-services-alternate: true
 ```
 
-# Pulsar source connectors can pass message properties to a target topic
+## Pulsar source connectors can pass message properties to a target topic
 
 In previous releases, Pulsar source connectors could not pass message properties to a target topic because the `forwardSourceMessageProperty` was not applied to the source connector.
 
 In this release, the `forwardSourceMessageProperty` parameter is added to the source connectors. You can use Function Mesh or the pulsar-admin CLI tool to pass message properties to the target topic.
 
-# Function Mesh provides multiple options for auto-scaling the number of Pods
+## Function Mesh provides multiple options for auto-scaling the number of Pods
 
 In previous releases, Function Mesh supported scaling Pods (Function instances or Connector instances) based on the CPU utilization automatically.
 
@@ -77,7 +77,7 @@ In this release, Function Mesh auto-scales the number of Pods based on the CPU u
 
 For details, see [scaling](/scaling.md).
 
-# Function Mesh supports creating Pulsar Functions by package URLs
+## Function Mesh supports creating Pulsar Functions by package URLs
 
 Pulsar 2.8 introduced the package management service, which enables you to manage your Pulsar Function and connector packages.
 

--- a/docs/releases/release-note-0-1-8.md
+++ b/docs/releases/release-note-0-1-8.md
@@ -6,7 +6,7 @@ id: release-note-0-1-8
 
 Here are some highlights of this release. For a full list of updates available for Release v0.1.8, check out [here](https://github.com/streamnative/function-mesh/releases/tag/v0.1.8).
 
-# Support running Pulsar functions and connectors with a default or a customized service account in Mesh Worker service
+## Support running Pulsar functions and connectors with a default or a customized service account in Mesh Worker service
 
 In this release, we added `defaultServiceAccountName` to `MeshWorkerServiceCustomConfig` to allow users to set the default service account for running the Pod.
 

--- a/docs/releases/release-note-0-1-9.md
+++ b/docs/releases/release-note-0-1-9.md
@@ -6,21 +6,21 @@ id: release-note-0-1-9
 
 Here are some highlights of this release. For a full list of updates available for Release v0.1.9, check out [Function Mesh change log](https://github.com/streamnative/function-mesh/releases/tag/v0.1.9).
 
-# Move the Function Mesh Worker service into a separate repository
+## Move the Function Mesh Worker service into a separate repository
 
 In this release, we moved the Function Mesh Worker service into a separate repository `streamnative/function-mesh-worker-service`. Therefore, the `function-mesh` repository does not include releases of the Function Mesh Worker service.
 
 For a detailed version matrix between Function Mesh and Function Mesh worker service, see [version matrix](/function-mesh-worker/function-mesh-worker-overview.md#version-matrix).
 
-# Support validating CRDs with WebHook
+## Support validating CRDs with WebHook
 
 In this release, we added [CRD validating markers](https://book.kubebuilder.io/reference/markers/crd-validation.html#crd-validation) to Function Mesh to support validating CRDs.
 
-# Supports custom images
+## Supports custom images
 
 In this release, we added `functionRunnerImages` to `MeshWorkerServiceCustomConfig` to allow users to use the Function Mesh Worker service to set the default function runner images for each Pulsar Functions runtime.
 
-# Support the `secretsMap` option
+## Support the `secretsMap` option
 
 In this release, Function Mesh Worker service can handle the `--secrets` option from the `pulsar-admin` CLI tool and transfer the secrets as `secretsMap` to the Function Mesh operator.
 

--- a/versioned_docs/version-0.1.10/releases/release-note-0-1-7.md
+++ b/versioned_docs/version-0.1.10/releases/release-note-0-1-7.md
@@ -6,7 +6,7 @@ id: release-note-0-1-7
 
 Here are some highlights of this release. For a full list of updates available for Release v0.1.7, check out [here](https://github.com/streamnative/function-mesh/releases/tag/v0.1.7).
 
-# YAML configuration supports multiple values
+## YAML configuration supports multiple values
 
 In previous releases, the Pulsar Function or connector configurations were declared as `map[string]string`, and nested or complex configurations shown below were not supported.
 
@@ -59,13 +59,13 @@ sinkConfig:
       use-services-alternate: true
 ```
 
-# Pulsar source connectors can pass message properties to a target topic
+## Pulsar source connectors can pass message properties to a target topic
 
 In previous releases, Pulsar source connectors could not pass message properties to a target topic because the `forwardSourceMessageProperty` was not applied to the source connector.
 
 In this release, the `forwardSourceMessageProperty` parameter is added to the source connectors. You can use Function Mesh or the pulsar-admin CLI tool to pass message properties to the target topic.
 
-# Function Mesh provides multiple options for auto-scaling the number of Pods
+## Function Mesh provides multiple options for auto-scaling the number of Pods
 
 In previous releases, Function Mesh supported scaling Pods (Function instances or Connector instances) based on the CPU utilization automatically.
 
@@ -77,7 +77,7 @@ In this release, Function Mesh auto-scales the number of Pods based on the CPU u
 
 For details, see [scaling](/scaling.md).
 
-# Function Mesh supports creating Pulsar Functions by package URLs
+## Function Mesh supports creating Pulsar Functions by package URLs
 
 Pulsar 2.8 introduced the package management service, which enables you to manage your Pulsar Function and connector packages.
 

--- a/versioned_docs/version-0.1.10/releases/release-note-0-1-8.md
+++ b/versioned_docs/version-0.1.10/releases/release-note-0-1-8.md
@@ -6,7 +6,7 @@ id: release-note-0-1-8
 
 Here are some highlights of this release. For a full list of updates available for Release v0.1.8, check out [here](https://github.com/streamnative/function-mesh/releases/tag/v0.1.8).
 
-# Support running Pulsar functions and connectors with a default or a customized service account in Mesh Worker service
+## Support running Pulsar functions and connectors with a default or a customized service account in Mesh Worker service
 
 In this release, we added `defaultServiceAccountName` to `MeshWorkerServiceCustomConfig` to allow users to set the default service account for running the Pod.
 

--- a/versioned_docs/version-0.1.10/releases/release-note-0-1-9.md
+++ b/versioned_docs/version-0.1.10/releases/release-note-0-1-9.md
@@ -6,21 +6,21 @@ id: release-note-0-1-9
 
 Here are some highlights of this release. For a full list of updates available for Release v0.1.9, check out [Function Mesh change log](https://github.com/streamnative/function-mesh/releases/tag/v0.1.9).
 
-# Move the Function Mesh Worker service into a separate repository
+## Move the Function Mesh Worker service into a separate repository
 
 In this release, we moved the Function Mesh Worker service into a separate repository `streamnative/function-mesh-worker-service`. Therefore, the `function-mesh` repository does not include releases of the Function Mesh Worker service.
 
 For a detailed version matrix between Function Mesh and Function Mesh worker service, see [version matrix](/function-mesh-worker/function-mesh-worker-overview.md#version-matrix).
 
-# Support validating CRDs with WebHook
+## Support validating CRDs with WebHook
 
 In this release, we added [CRD validating markers](https://book.kubebuilder.io/reference/markers/crd-validation.html#crd-validation) to Function Mesh to support validating CRDs.
 
-# Supports custom images
+## Supports custom images
 
 In this release, we added `functionRunnerImages` to `MeshWorkerServiceCustomConfig` to allow users to use the Function Mesh Worker service to set the default function runner images for each Pulsar Functions runtime.
 
-# Support the `secretsMap` option
+## Support the `secretsMap` option
 
 In this release, Function Mesh Worker service can handle the `--secrets` option from the `pulsar-admin` CLI tool and transfer the secrets as `secretsMap` to the Function Mesh operator.
 

--- a/versioned_docs/version-0.1.7/releases/release-note-0-1-7.md
+++ b/versioned_docs/version-0.1.7/releases/release-note-0-1-7.md
@@ -6,7 +6,7 @@ id: release-note-0-1-7
 
 Here are some highlights of this release. For a full list of updates available for Release v0.1.7, check out [here](https://github.com/streamnative/function-mesh/releases/tag/v0.1.7).
 
-# YAML configuration supports multiple values
+## YAML configuration supports multiple values
 
 In previous releases, the Pulsar Function or connector configurations were declared as `map[string]string`, and nested or complex configurations shown below were not supported.
 
@@ -59,13 +59,13 @@ sinkConfig:
       use-services-alternate: true
 ```
 
-# Pulsar source connectors can pass message properties to a target topic
+## Pulsar source connectors can pass message properties to a target topic
 
 In previous releases, Pulsar source connectors could not pass message properties to a target topic because the `forwardSourceMessageProperty` was not applied to the source connector.
 
 In this release, the `forwardSourceMessageProperty` parameter is added to the source connectors. You can use Function Mesh or the pulsar-admin CLI tool to pass message properties to the target topic.
 
-# Function Mesh provides multiple options for auto-scaling the number of Pods
+## Function Mesh provides multiple options for auto-scaling the number of Pods
 
 In previous releases, Function Mesh supported scaling Pods (Function instances or Connector instances) based on the CPU utilization automatically.
 
@@ -77,7 +77,7 @@ In this release, Function Mesh auto-scales the number of Pods based on the CPU u
 
 For details, see [scaling](/scaling.md).
 
-# Function Mesh supports creating Pulsar Functions by package URLs
+## Function Mesh supports creating Pulsar Functions by package URLs
 
 Pulsar 2.8 introduced the package management service, which enables you to manage your Pulsar Function and connector packages.
 

--- a/versioned_docs/version-0.1.8/releases/release-note-0-1-7.md
+++ b/versioned_docs/version-0.1.8/releases/release-note-0-1-7.md
@@ -6,7 +6,7 @@ id: release-note-0-1-7
 
 Here are some highlights of this release. For a full list of updates available for Release v0.1.7, check out [here](https://github.com/streamnative/function-mesh/releases/tag/v0.1.7).
 
-# YAML configuration supports multiple values
+## YAML configuration supports multiple values
 
 In previous releases, the Pulsar Function or connector configurations were declared as `map[string]string`, and nested or complex configurations shown below were not supported.
 
@@ -59,13 +59,13 @@ sinkConfig:
       use-services-alternate: true
 ```
 
-# Pulsar source connectors can pass message properties to a target topic
+## Pulsar source connectors can pass message properties to a target topic
 
 In previous releases, Pulsar source connectors could not pass message properties to a target topic because the `forwardSourceMessageProperty` was not applied to the source connector.
 
 In this release, the `forwardSourceMessageProperty` parameter is added to the source connectors. You can use Function Mesh or the pulsar-admin CLI tool to pass message properties to the target topic.
 
-# Function Mesh provides multiple options for auto-scaling the number of Pods
+## Function Mesh provides multiple options for auto-scaling the number of Pods
 
 In previous releases, Function Mesh supported scaling Pods (Function instances or Connector instances) based on the CPU utilization automatically.
 
@@ -77,7 +77,7 @@ In this release, Function Mesh auto-scales the number of Pods based on the CPU u
 
 For details, see [scaling](/scaling.md).
 
-# Function Mesh supports creating Pulsar Functions by package URLs
+## Function Mesh supports creating Pulsar Functions by package URLs
 
 Pulsar 2.8 introduced the package management service, which enables you to manage your Pulsar Function and connector packages.
 

--- a/versioned_docs/version-0.1.8/releases/release-note-0-1-8.md
+++ b/versioned_docs/version-0.1.8/releases/release-note-0-1-8.md
@@ -6,7 +6,7 @@ id: release-note-0-1-8
 
 Here are some highlights of this release. For a full list of updates available for Release v0.1.8, check out [here](https://github.com/streamnative/function-mesh/releases/tag/v0.1.8).
 
-# Support running Pulsar functions and connectors with a default or a customized service account in Mesh Worker service
+## Support running Pulsar functions and connectors with a default or a customized service account in Mesh Worker service
 
 In this release, we added `defaultServiceAccountName` to `MeshWorkerServiceCustomConfig` to allow users to set the default service account for running the Pod.
 

--- a/versioned_docs/version-0.1.9/releases/release-note-0-1-7.md
+++ b/versioned_docs/version-0.1.9/releases/release-note-0-1-7.md
@@ -6,7 +6,7 @@ id: release-note-0-1-7
 
 Here are some highlights of this release. For a full list of updates available for Release v0.1.7, check out [here](https://github.com/streamnative/function-mesh/releases/tag/v0.1.7).
 
-# YAML configuration supports multiple values
+## YAML configuration supports multiple values
 
 In previous releases, the Pulsar Function or connector configurations were declared as `map[string]string`, and nested or complex configurations shown below were not supported.
 
@@ -59,13 +59,13 @@ sinkConfig:
       use-services-alternate: true
 ```
 
-# Pulsar source connectors can pass message properties to a target topic
+## Pulsar source connectors can pass message properties to a target topic
 
 In previous releases, Pulsar source connectors could not pass message properties to a target topic because the `forwardSourceMessageProperty` was not applied to the source connector.
 
 In this release, the `forwardSourceMessageProperty` parameter is added to the source connectors. You can use Function Mesh or the pulsar-admin CLI tool to pass message properties to the target topic.
 
-# Function Mesh provides multiple options for auto-scaling the number of Pods
+## Function Mesh provides multiple options for auto-scaling the number of Pods
 
 In previous releases, Function Mesh supported scaling Pods (Function instances or Connector instances) based on the CPU utilization automatically.
 
@@ -77,7 +77,7 @@ In this release, Function Mesh auto-scales the number of Pods based on the CPU u
 
 For details, see [scaling](/scaling.md).
 
-# Function Mesh supports creating Pulsar Functions by package URLs
+## Function Mesh supports creating Pulsar Functions by package URLs
 
 Pulsar 2.8 introduced the package management service, which enables you to manage your Pulsar Function and connector packages.
 

--- a/versioned_docs/version-0.1.9/releases/release-note-0-1-8.md
+++ b/versioned_docs/version-0.1.9/releases/release-note-0-1-8.md
@@ -6,7 +6,7 @@ id: release-note-0-1-8
 
 Here are some highlights of this release. For a full list of updates available for Release v0.1.8, check out [here](https://github.com/streamnative/function-mesh/releases/tag/v0.1.8).
 
-# Support running Pulsar functions and connectors with a default or a customized service account in Mesh Worker service
+## Support running Pulsar functions and connectors with a default or a customized service account in Mesh Worker service
 
 In this release, we added `defaultServiceAccountName` to `MeshWorkerServiceCustomConfig` to allow users to set the default service account for running the Pod.
 

--- a/versioned_docs/version-0.1.9/releases/release-note-0-1-9.md
+++ b/versioned_docs/version-0.1.9/releases/release-note-0-1-9.md
@@ -6,21 +6,21 @@ id: release-note-0-1-9
 
 Here are some highlights of this release. For a full list of updates available for Release v0.1.9, check out [Function Mesh change log](https://github.com/streamnative/function-mesh/releases/tag/v0.1.9).
 
-# Move the Function Mesh Worker service into a separate repository
+## Move the Function Mesh Worker service into a separate repository
 
 In this release, we moved the Function Mesh Worker service into a separate repository `streamnative/function-mesh-worker-service`. Therefore, the `function-mesh` repository does not include releases of the Function Mesh Worker service.
 
 For a detailed version matrix between Function Mesh and Function Mesh worker service, see [version matrix](/function-mesh-worker/function-mesh-worker-overview.md#version-matrix).
 
-# Support validating CRDs with WebHook
+## Support validating CRDs with WebHook
 
 In this release, we added [CRD validating markers](https://book.kubebuilder.io/reference/markers/crd-validation.html#crd-validation) to Function Mesh to support validating CRDs.
 
-# Supports custom images
+## Supports custom images
 
 In this release, we added `functionRunnerImages` to `MeshWorkerServiceCustomConfig` to allow users to use the Function Mesh Worker service to set the default function runner images for each Pulsar Functions runtime.
 
-# Support the `secretsMap` option
+## Support the `secretsMap` option
 
 In this release, Function Mesh Worker service can handle the `--secrets` option from the `pulsar-admin` CLI tool and transfer the secrets as `secretsMap` to the Function Mesh operator.
 


### PR DESCRIPTION
### Motivation
The Function mesh doc should started with Heading 2. Release notes in v0.1.7-latest  use Heading 1.

###  Modification

- Update Heading levels in release notes
- Affected releases: v0.1.7 -- latest

