### PR TITLE
Update field typos in CRD docs

### DIFF
--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -15,20 +15,20 @@ This table lists sink configurations.
 | `classname` | The class name of a sink connector. |
 | `tenant` | The tenant of a sink connector. |
 | `namespace` | The Pulsar namespace of a sink connector. |
-| `ClusterName` | The Pulsar cluster of a sink connector. |
-| `Replicas`| The number of instances that you want to run this sink connector. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SinkConfig` | The sink connector configurations in YAML format.|
-| `Timeout` | The message timeout in milliseconds. |
-| `NegativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `RetainOrdering` | The sink connector consumes and processes messages in order. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
-| `SubscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a sink connector. |
+| `replicas`| The number of instances that you want to run this sink connector. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sinkConfig` | The sink connector configurations in YAML format.|
+| `timeout` | The message timeout in milliseconds. |
+| `negativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `retainOrdering` | The sink connector consumes and processes messages in order. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
+| `subscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -50,10 +50,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Resources
 
@@ -63,9 +63,9 @@ If the node where a Pod is running has enough of a resource available, it is pos
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
+Function Mesh provides the `secretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
 
-The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
+The `secretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
 
 | Field | Description |
 | --- | --- |
@@ -85,7 +85,7 @@ metadata:
 type: Opaque
 ```
 
-To use it in Pulsar Functions in a secure way, you can define the `SecretsMap` in the Custom Resource:
+To use it in Pulsar Functions in a secure way, you can define the `secretsMap` in the Custom Resource:
 
 ```yaml
 secretsMap:
@@ -101,7 +101,7 @@ Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("u
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -142,18 +142,18 @@ Function Mesh supports customizing the Pod running Pulsar connectors. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -15,12 +15,12 @@ This table lists source configurations.
 | `classname` | The class name of a source connector. |
 | `tenant` | The tenant of a source connector. |
 | `namespace` | The Pulsar namespace of a source connector. |
-| `ClusterName` | The Pulsar cluster of a source connector. |
-| `Replicas`| The number of instances that you want to run this source connector. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SourceConfig` | The source connector configurations in YAML format. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `ForwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
+| `clusterName` | The Pulsar cluster of a source connector. |
+| `replicas`| The number of instances that you want to run this source connector. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sourceConfig` | The source connector configurations in YAML format. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
 
 ## Images
 
@@ -42,11 +42,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: <br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher. 
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: <br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher. 
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -56,9 +56,9 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
+Function Mesh provides the `secretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
 
-The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
+The `secretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
 
 | Field | Description |
 | --- | --- |
@@ -78,7 +78,7 @@ metadata:
 type: Opaque
 ```
 
-To use it in Pulsar Functions in a secure way, you can define the `SecretsMap` in the Custom Resource:
+To use it in Pulsar Functions in a secure way, you can define the `secretsMap` in the Custom Resource:
 
 ```yaml
 secretsMap:
@@ -94,7 +94,7 @@ Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("u
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -135,18 +135,18 @@ Function Mesh supports customizing the Pod running connectors. This table lists 
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -16,22 +16,22 @@ This table lists Pulsar Function configurations.
 | `classname` | The class name of a Pulsar Function. |
 | `tenant` | The tenant of a Pulsar Function. |
 | `namespace` | The Pulsar namespace of a Pulsar Function. |
-| `ClusterName` | The Pulsar cluster of a Pulsar Function. |
-| `Replicas`| The number of instances that you want to run this Pulsar Function. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `Timeout` | The message timeout in milliseconds. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
-| `FuncConfig` | Pulsar Functions configurations in YAML format. |
-| `LogTopic` | The topic to which the logs of a Pulsar Function are produced. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `ForwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
-| `RetainOrdering` | Function consumes and processes messages in order. |
-| `RetainKeyOrdering`| Configure whether to retain the key order of messages. |
-| `SubscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a Pulsar Function. |
+| `replicas`| The number of instances that you want to run this Pulsar Function. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `timeout` | The message timeout in milliseconds. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
+| `funcConfig` | Pulsar Functions configurations in YAML format. |
+| `logTopic` | The topic to which the logs of a Pulsar Function are produced. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
+| `retainOrdering` | Function consumes and processes messages in order. |
+| `retainKeyOrdering`| Configure whether to retain the key order of messages. |
+| `subscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -59,10 +59,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Output
 
@@ -70,11 +70,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: < br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher.
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: < br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher.
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -84,9 +84,9 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
+Function Mesh provides the `secretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
 
-The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
+The `secretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
 
 | Field | Description |
 | --- | --- |
@@ -106,7 +106,7 @@ metadata:
 type: Opaque
 ```
 
-To use it in Pulsar Functions in a secure way, you can define the `SecretsMap` in the Custom Resource:
+To use it in Pulsar Functions in a secure way, you can define the `secretsMap` in the Custom Resource:
 
 ```yaml
 secretsMap:
@@ -122,7 +122,7 @@ Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("u
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -165,18 +165,18 @@ Function Mesh supports customizing the Pod running function instance. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in Pulsar Functions. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in Pulsar Functions. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/docs/releases/release-note-0-1-6.md
+++ b/docs/releases/release-note-0-1-6.md
@@ -24,6 +24,6 @@ In release v0.1.4, we introduced the Function Mesh Worker service, which ensures
 
 In this release, we expose the `serviceAccountName` option in the CRDs of Pulsar Functions and connectors. Therefore, users can run Pulsar Functions and connectors using the Function Mesh Worker service.
 
-## Fix the NPE that is generated when the `AutoAck` option is not set
+## Fix the NPE that is generated when the `autoAck` option is not set
 
-If the `AutoAck` option is not set in the CRDs of Pulsar Functions and connectors, a Null Pointer Exception (NPE) is generated when creating a function, connector (sink or source) using the pulsar-admin CLI tool. To fix this bug, we set the `AutoAck` option to `true` by default. Therefore, users can successfully create Pulsar Functions and connectors.
+If the `autoAck` option is not set in the CRDs of Pulsar Functions and connectors, a Null Pointer Exception (NPE) is generated when creating a function, connector (sink or source) using the pulsar-admin CLI tool. To fix this bug, we set the `autoAck` option to `true` by default. Therefore, users can successfully create Pulsar Functions and connectors.

--- a/sidebars.js
+++ b/sidebars.js
@@ -62,7 +62,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Releases',
-      items: ['releases/release-note-0-1-4', 'releases/release-note-0-1-5', 'releases/release-note-0-1-6', 'releases/release-note-0-1-7', 'releases/release-note-0-1-8', 'releases/release-note-0-1-9', , 'releases/release-note-0-2-0'],
+      items: ['releases/release-note-0-1-4', 'releases/release-note-0-1-5', 'releases/release-note-0-1-6', 'releases/release-note-0-1-7', 'releases/release-note-0-1-8', 'releases/release-note-0-1-9', 'releases/release-note-0-2-0'],
     },
   ],
 }

--- a/versioned_docs/version-0.1.10/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.1.10/connectors/io-crd-config/sink-crd-config.md
@@ -15,20 +15,20 @@ This table lists sink configurations.
 | `classname` | The class name of a sink connector. |
 | `tenant` | The tenant of a sink connector. |
 | `namespace` | The Pulsar namespace of a sink connector. |
-| `ClusterName` | The Pulsar cluster of a sink connector. |
-| `Replicas`| The number of instances that you want to run this sink connector. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SinkConfig` | The sink connector configurations in YAML format.|
-| `Timeout` | The message timeout in milliseconds. |
-| `NegativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `RetainOrdering` | The sink connector consumes and processes messages in order. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
-| `SubscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a sink connector. |
+| `replicas`| The number of instances that you want to run this sink connector. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sinkConfig` | The sink connector configurations in YAML format.|
+| `timeout` | The message timeout in milliseconds. |
+| `negativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `retainOrdering` | The sink connector consumes and processes messages in order. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
+| `subscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -50,10 +50,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Resources
 
@@ -63,9 +63,9 @@ If the node where a Pod is running has enough of a resource available, it is pos
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
+Function Mesh provides the `secretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
 
-The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
+The `secretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
 
 | Field | Description |
 | --- | --- |
@@ -85,7 +85,7 @@ metadata:
 type: Opaque
 ```
 
-To use it in Pulsar Functions in a secure way, you can define the `SecretsMap` in the Custom Resource:
+To use it in Pulsar Functions in a secure way, you can define the `secretsMap` in the Custom Resource:
 
 ```yaml
 secretsMap:
@@ -101,7 +101,7 @@ Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("u
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -142,18 +142,18 @@ Function Mesh supports customizing the Pod running Pulsar connectors. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/versioned_docs/version-0.1.10/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.1.10/connectors/io-crd-config/source-crd-config.md
@@ -15,12 +15,12 @@ This table lists source configurations.
 | `classname` | The class name of a source connector. |
 | `tenant` | The tenant of a source connector. |
 | `namespace` | The Pulsar namespace of a source connector. |
-| `ClusterName` | The Pulsar cluster of a source connector. |
-| `Replicas`| The number of instances that you want to run this source connector. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SourceConfig` | The source connector configurations in YAML format. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `ForwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
+| `clusterName` | The Pulsar cluster of a source connector. |
+| `replicas`| The number of instances that you want to run this source connector. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sourceConfig` | The source connector configurations in YAML format. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
 
 ## Images
 
@@ -42,11 +42,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: <br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher. 
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: <br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher. 
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -56,9 +56,9 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
+Function Mesh provides the `secretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
 
-The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
+The `secretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
 
 | Field | Description |
 | --- | --- |
@@ -78,7 +78,7 @@ metadata:
 type: Opaque
 ```
 
-To use it in Pulsar Functions in a secure way, you can define the `SecretsMap` in the Custom Resource:
+To use it in Pulsar Functions in a secure way, you can define the `secretsMap` in the Custom Resource:
 
 ```yaml
 secretsMap:
@@ -94,7 +94,7 @@ Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("u
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -135,18 +135,18 @@ Function Mesh supports customizing the Pod running connectors. This table lists 
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/versioned_docs/version-0.1.10/functions/function-crd.md
+++ b/versioned_docs/version-0.1.10/functions/function-crd.md
@@ -16,22 +16,22 @@ This table lists Pulsar Function configurations.
 | `classname` | The class name of a Pulsar Function. |
 | `tenant` | The tenant of a Pulsar Function. |
 | `namespace` | The Pulsar namespace of a Pulsar Function. |
-| `ClusterName` | The Pulsar cluster of a Pulsar Function. |
-| `Replicas`| The number of instances that you want to run this Pulsar Function. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `Timeout` | The message timeout in milliseconds. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
-| `FuncConfig` | Pulsar Functions configurations in YAML format. |
-| `LogTopic` | The topic to which the logs of a Pulsar Function are produced. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `ForwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
-| `RetainOrdering` | Function consumes and processes messages in order. |
-| `RetainKeyOrdering`| Configure whether to retain the key order of messages. |
-| `SubscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a Pulsar Function. |
+| `replicas`| The number of instances that you want to run this Pulsar Function. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `timeout` | The message timeout in milliseconds. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
+| `funcConfig` | Pulsar Functions configurations in YAML format. |
+| `logTopic` | The topic to which the logs of a Pulsar Function are produced. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
+| `retainOrdering` | Function consumes and processes messages in order. |
+| `retainKeyOrdering`| Configure whether to retain the key order of messages. |
+| `subscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -59,10 +59,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Output
 
@@ -70,11 +70,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: < br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher.
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: < br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher.
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -84,9 +84,9 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
+Function Mesh provides the `secretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
 
-The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
+The `secretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
 
 | Field | Description |
 | --- | --- |
@@ -106,7 +106,7 @@ metadata:
 type: Opaque
 ```
 
-To use it in Pulsar Functions in a secure way, you can define the `SecretsMap` in the Custom Resource:
+To use it in Pulsar Functions in a secure way, you can define the `secretsMap` in the Custom Resource:
 
 ```yaml
 secretsMap:
@@ -122,7 +122,7 @@ Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("u
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -165,18 +165,18 @@ Function Mesh supports customizing the Pod running function instance. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in Pulsar Functions. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in Pulsar Functions. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/versioned_docs/version-0.1.10/releases/release-note-0-1-6.md
+++ b/versioned_docs/version-0.1.10/releases/release-note-0-1-6.md
@@ -24,6 +24,6 @@ In release v0.1.4, we introduced the Function Mesh Worker service, which ensures
 
 In this release, we expose the `serviceAccountName` option in the CRDs of Pulsar Functions and connectors. Therefore, users can run Pulsar Functions and connectors using the Function Mesh Worker service.
 
-## Fix the NPE that is generated when the `AutoAck` option is not set
+## Fix the NPE that is generated when the `autoAck` option is not set
 
-If the `AutoAck` option is not set in the CRDs of Pulsar Functions and connectors, a Null Pointer Exception (NPE) is generated when creating a function, connector (sink or source) using the pulsar-admin CLI tool. To fix this bug, we set the `AutoAck` option to `true` by default. Therefore, users can successfully create Pulsar Functions and connectors.
+If the `autoAck` option is not set in the CRDs of Pulsar Functions and connectors, a Null Pointer Exception (NPE) is generated when creating a function, connector (sink or source) using the pulsar-admin CLI tool. To fix this bug, we set the `autoAck` option to `true` by default. Therefore, users can successfully create Pulsar Functions and connectors.

--- a/versioned_docs/version-0.1.11/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.1.11/connectors/io-crd-config/sink-crd-config.md
@@ -15,20 +15,20 @@ This table lists sink configurations.
 | `classname` | The class name of a sink connector. |
 | `tenant` | The tenant of a sink connector. |
 | `namespace` | The Pulsar namespace of a sink connector. |
-| `ClusterName` | The Pulsar cluster of a sink connector. |
-| `Replicas`| The number of instances that you want to run this sink connector. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SinkConfig` | The sink connector configurations in YAML format.|
-| `Timeout` | The message timeout in milliseconds. |
-| `NegativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `RetainOrdering` | The sink connector consumes and processes messages in order. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
-| `SubscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a sink connector. |
+| `replicas`| The number of instances that you want to run this sink connector. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sinkConfig` | The sink connector configurations in YAML format.|
+| `timeout` | The message timeout in milliseconds. |
+| `negativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `retainOrdering` | The sink connector consumes and processes messages in order. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
+| `subscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -50,10 +50,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Resources
 
@@ -63,9 +63,9 @@ If the node where a Pod is running has enough of a resource available, it is pos
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
+Function Mesh provides the `secretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
 
-The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
+The `secretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
 
 | Field | Description |
 | --- | --- |
@@ -85,7 +85,7 @@ metadata:
 type: Opaque
 ```
 
-To use it in Pulsar Functions in a secure way, you can define the `SecretsMap` in the Custom Resource:
+To use it in Pulsar Functions in a secure way, you can define the `secretsMap` in the Custom Resource:
 
 ```yaml
 secretsMap:
@@ -101,7 +101,7 @@ Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("u
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -142,18 +142,18 @@ Function Mesh supports customizing the Pod running Pulsar connectors. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/versioned_docs/version-0.1.11/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.1.11/connectors/io-crd-config/source-crd-config.md
@@ -15,12 +15,12 @@ This table lists source configurations.
 | `classname` | The class name of a source connector. |
 | `tenant` | The tenant of a source connector. |
 | `namespace` | The Pulsar namespace of a source connector. |
-| `ClusterName` | The Pulsar cluster of a source connector. |
-| `Replicas`| The number of instances that you want to run this source connector. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SourceConfig` | The source connector configurations in YAML format. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `ForwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
+| `clusterName` | The Pulsar cluster of a source connector. |
+| `replicas`| The number of instances that you want to run this source connector. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sourceConfig` | The source connector configurations in YAML format. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
 
 ## Images
 
@@ -42,11 +42,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: <br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher. 
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: <br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher. 
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -56,9 +56,9 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
+Function Mesh provides the `secretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
 
-The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
+The `secretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
 
 | Field | Description |
 | --- | --- |
@@ -78,7 +78,7 @@ metadata:
 type: Opaque
 ```
 
-To use it in Pulsar Functions in a secure way, you can define the `SecretsMap` in the Custom Resource:
+To use it in Pulsar Functions in a secure way, you can define the `secretsMap` in the Custom Resource:
 
 ```yaml
 secretsMap:
@@ -94,7 +94,7 @@ Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("u
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -135,18 +135,18 @@ Function Mesh supports customizing the Pod running connectors. This table lists 
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/versioned_docs/version-0.1.11/functions/function-crd.md
+++ b/versioned_docs/version-0.1.11/functions/function-crd.md
@@ -16,22 +16,22 @@ This table lists Pulsar Function configurations.
 | `classname` | The class name of a Pulsar Function. |
 | `tenant` | The tenant of a Pulsar Function. |
 | `namespace` | The Pulsar namespace of a Pulsar Function. |
-| `ClusterName` | The Pulsar cluster of a Pulsar Function. |
-| `Replicas`| The number of instances that you want to run this Pulsar Function. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `Timeout` | The message timeout in milliseconds. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
-| `FuncConfig` | Pulsar Functions configurations in YAML format. |
-| `LogTopic` | The topic to which the logs of a Pulsar Function are produced. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `ForwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
-| `RetainOrdering` | Function consumes and processes messages in order. |
-| `RetainKeyOrdering`| Configure whether to retain the key order of messages. |
-| `SubscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a Pulsar Function. |
+| `replicas`| The number of instances that you want to run this Pulsar Function. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `timeout` | The message timeout in milliseconds. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
+| `funcConfig` | Pulsar Functions configurations in YAML format. |
+| `logTopic` | The topic to which the logs of a Pulsar Function are produced. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
+| `retainOrdering` | Function consumes and processes messages in order. |
+| `retainKeyOrdering`| Configure whether to retain the key order of messages. |
+| `subscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -59,10 +59,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Output
 
@@ -70,11 +70,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: < br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher.
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: < br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher.
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -84,9 +84,9 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
+Function Mesh provides the `secretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
 
-The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
+The `secretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
 
 | Field | Description |
 | --- | --- |
@@ -106,7 +106,7 @@ metadata:
 type: Opaque
 ```
 
-To use it in Pulsar Functions in a secure way, you can define the `SecretsMap` in the Custom Resource:
+To use it in Pulsar Functions in a secure way, you can define the `secretsMap` in the Custom Resource:
 
 ```yaml
 secretsMap:
@@ -122,7 +122,7 @@ Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("u
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -165,18 +165,18 @@ Function Mesh supports customizing the Pod running function instance. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in Pulsar Functions. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in Pulsar Functions. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/versioned_docs/version-0.1.11/releases/release-note-0-1-6.md
+++ b/versioned_docs/version-0.1.11/releases/release-note-0-1-6.md
@@ -24,6 +24,6 @@ In release v0.1.4, we introduced the Function Mesh Worker service, which ensures
 
 In this release, we expose the `serviceAccountName` option in the CRDs of Pulsar Functions and connectors. Therefore, users can run Pulsar Functions and connectors using the Function Mesh Worker service.
 
-## Fix the NPE that is generated when the `AutoAck` option is not set
+## Fix the NPE that is generated when the `autoAck` option is not set
 
-If the `AutoAck` option is not set in the CRDs of Pulsar Functions and connectors, a Null Pointer Exception (NPE) is generated when creating a function, connector (sink or source) using the pulsar-admin CLI tool. To fix this bug, we set the `AutoAck` option to `true` by default. Therefore, users can successfully create Pulsar Functions and connectors.
+If the `autoAck` option is not set in the CRDs of Pulsar Functions and connectors, a Null Pointer Exception (NPE) is generated when creating a function, connector (sink or source) using the pulsar-admin CLI tool. To fix this bug, we set the `autoAck` option to `true` by default. Therefore, users can successfully create Pulsar Functions and connectors.

--- a/versioned_docs/version-0.1.4/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.1.4/connectors/io-crd-config/sink-crd-config.md
@@ -14,20 +14,20 @@ This table lists sink configurations.
 | `name` | The name of a sink connector. |
 | `classname` | The class name of a sink connector. |
 | `tenant` | The tenant of a sink connector. |
-| `ClusterName` | The Pulsar cluster of a sink connector. |
-| `Replicas`| The number of instances that you want to run this sink connector. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SinkConfig` | The map to a ConfigMap specifying the configuration of a sink connector. |
-| `Timeout` | The message timeout in milliseconds. |
-| `NegativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`. |
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `RetainOrdering` | The sink connector consumes and processes messages in order. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
-| `SubscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a sink connector. |
+| `replicas`| The number of instances that you want to run this sink connector. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sinkConfig` | The map to a ConfigMap specifying the configuration of a sink connector. |
+| `timeout` | The message timeout in milliseconds. |
+| `negativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`. |
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `retainOrdering` | The sink connector consumes and processes messages in order. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
+| `subscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -49,10 +49,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Resources
 
@@ -93,14 +93,14 @@ Function Mesh supports customizing the Pod running Pulsar connectors. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `InitContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `initContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |

--- a/versioned_docs/version-0.1.4/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.1.4/connectors/io-crd-config/source-crd-config.md
@@ -14,11 +14,11 @@ This table lists source configurations.
 | `name` | The name of a source connector. |
 | `classname` | The class name of a source connector. |
 | `tenant` | The tenant of a source connector. |
-| `ClusterName` | The Pulsar cluster of a source connector. |
-| `Replicas`| The number of instances that you want to run this source connector. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SourceConfig` | The map to a ConfigMap specifying the configuration of a source connector. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
+| `clusterName` | The Pulsar cluster of a source connector. |
+| `replicas`| The number of instances that you want to run this source connector. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sourceConfig` | The map to a ConfigMap specifying the configuration of a source connector. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
 
 ## Images
 
@@ -40,11 +40,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: <br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher. 
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: <br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher. 
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -85,14 +85,14 @@ Function Mesh supports customizing the Pod running connectors. This table lists 
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |

--- a/versioned_docs/version-0.1.4/functions/function-crd.md
+++ b/versioned_docs/version-0.1.4/functions/function-crd.md
@@ -16,21 +16,21 @@ This table lists Pulsar Function configurations.
 | `classname` | The class name of a Pulsar Function. |
 | `tenant` | The tenant of a Pulsar Function. |
 | `namespace` | The namespace of a Pulsar Function. |
-| `ClusterName` | The Pulsar cluster of a Pulsar Function. |
-| `Replicas`| The number of instances that you want to run this Pulsar Function. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `Timeout` | The message timeout in milliseconds. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
-| `FuncConfig` | The map to a ConfigMap specifying the configuration of a Pulsar function. |
-| `LogTopic` | The topic to which the logs of a Pulsar Function are produced. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`. |
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `RetainOrdering` | Function consumes and processes messages in order. |
-| `RetainKeyOrdering`| Configure whether to retain the key order of messages. |
-| `SubscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a Pulsar Function. |
+| `replicas`| The number of instances that you want to run this Pulsar Function. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `timeout` | The message timeout in milliseconds. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
+| `funcConfig` | The map to a ConfigMap specifying the configuration of a Pulsar function. |
+| `logTopic` | The topic to which the logs of a Pulsar Function are produced. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`. |
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `retainOrdering` | Function consumes and processes messages in order. |
+| `retainKeyOrdering`| Configure whether to retain the key order of messages. |
+| `subscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -58,10 +58,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Output
 
@@ -69,11 +69,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: < br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher.
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: < br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher.
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -116,14 +116,14 @@ Function Mesh supports customizing the Pod running function instance. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |

--- a/versioned_docs/version-0.1.5/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.1.5/connectors/io-crd-config/sink-crd-config.md
@@ -14,20 +14,20 @@ This table lists sink configurations.
 | `name` | The name of a sink connector. |
 | `classname` | The class name of a sink connector. |
 | `tenant` | The tenant of a sink connector. |
-| `ClusterName` | The Pulsar cluster of a sink connector. |
-| `Replicas`| The number of instances that you want to run this sink connector. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SinkConfig` | The map to a ConfigMap specifying the configuration of a sink connector. |
-| `Timeout` | The message timeout in milliseconds. |
-| `NegativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`. |
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `RetainOrdering` | The sink connector consumes and processes messages in order. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
-| `SubscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a sink connector. |
+| `replicas`| The number of instances that you want to run this sink connector. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sinkConfig` | The map to a ConfigMap specifying the configuration of a sink connector. |
+| `timeout` | The message timeout in milliseconds. |
+| `negativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`. |
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `retainOrdering` | The sink connector consumes and processes messages in order. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
+| `subscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -49,10 +49,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Resources
 
@@ -62,7 +62,7 @@ If the node where a Pod is running has enough of a resource available, it is pos
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -103,14 +103,14 @@ Function Mesh supports customizing the Pod running Pulsar connectors. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `InitContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `initContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |

--- a/versioned_docs/version-0.1.5/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.1.5/connectors/io-crd-config/source-crd-config.md
@@ -14,11 +14,11 @@ This table lists source configurations.
 | `name` | The name of a source connector. |
 | `classname` | The class name of a source connector. |
 | `tenant` | The tenant of a source connector. |
-| `ClusterName` | The Pulsar cluster of a source connector. |
-| `Replicas`| The number of instances that you want to run this source connector. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SourceConfig` | The map to a ConfigMap specifying the configuration of a source connector. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
+| `clusterName` | The Pulsar cluster of a source connector. |
+| `replicas`| The number of instances that you want to run this source connector. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sourceConfig` | The map to a ConfigMap specifying the configuration of a source connector. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
 
 ## Images
 
@@ -40,11 +40,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: <br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher. 
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: <br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher. 
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -54,7 +54,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -95,14 +95,14 @@ Function Mesh supports customizing the Pod running connectors. This table lists 
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |

--- a/versioned_docs/version-0.1.5/functions/function-crd.md
+++ b/versioned_docs/version-0.1.5/functions/function-crd.md
@@ -16,21 +16,21 @@ This table lists Pulsar Function configurations.
 | `classname` | The class name of a Pulsar Function. |
 | `tenant` | The tenant of a Pulsar Function. |
 | `namespace` | The namespace of a Pulsar Function. |
-| `ClusterName` | The Pulsar cluster of a Pulsar Function. |
-| `Replicas`| The number of instances that you want to run this Pulsar Function. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `Timeout` | The message timeout in milliseconds. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
-| `FuncConfig` | The map to a ConfigMap specifying the configuration of a Pulsar function. |
-| `LogTopic` | The topic to which the logs of a Pulsar Function are produced. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`. |
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `RetainOrdering` | Function consumes and processes messages in order. |
-| `RetainKeyOrdering`| Configure whether to retain the key order of messages. |
-| `SubscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a Pulsar Function. |
+| `replicas`| The number of instances that you want to run this Pulsar Function. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `timeout` | The message timeout in milliseconds. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
+| `funcConfig` | The map to a ConfigMap specifying the configuration of a Pulsar function. |
+| `logTopic` | The topic to which the logs of a Pulsar Function are produced. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`. |
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `retainOrdering` | Function consumes and processes messages in order. |
+| `retainKeyOrdering`| Configure whether to retain the key order of messages. |
+| `subscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -58,10 +58,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Output
 
@@ -69,11 +69,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: < br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher.
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: < br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher.
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -83,7 +83,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -126,14 +126,14 @@ Function Mesh supports customizing the Pod running function instance. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |

--- a/versioned_docs/version-0.1.6/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.1.6/connectors/io-crd-config/sink-crd-config.md
@@ -14,20 +14,20 @@ This table lists sink configurations.
 | `name` | The name of a sink connector. |
 | `classname` | The class name of a sink connector. |
 | `tenant` | The tenant of a sink connector. |
-| `ClusterName` | The Pulsar cluster of a sink connector. |
-| `Replicas`| The number of instances that you want to run this sink connector. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SinkConfig` | The map to a ConfigMap specifying the configuration of a sink connector. |
-| `Timeout` | The message timeout in milliseconds. |
-| `NegativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `RetainOrdering` | The sink connector consumes and processes messages in order. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
-| `SubscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a sink connector. |
+| `replicas`| The number of instances that you want to run this sink connector. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sinkConfig` | The map to a ConfigMap specifying the configuration of a sink connector. |
+| `timeout` | The message timeout in milliseconds. |
+| `negativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `retainOrdering` | The sink connector consumes and processes messages in order. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
+| `subscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -49,10 +49,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Resources
 
@@ -62,7 +62,7 @@ If the node where a Pod is running has enough of a resource available, it is pos
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -103,15 +103,15 @@ Function Mesh supports customizing the Pod running Pulsar connectors. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |

--- a/versioned_docs/version-0.1.6/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.1.6/connectors/io-crd-config/source-crd-config.md
@@ -14,11 +14,11 @@ This table lists source configurations.
 | `name` | The name of a source connector. |
 | `classname` | The class name of a source connector. |
 | `tenant` | The tenant of a source connector. |
-| `ClusterName` | The Pulsar cluster of a source connector. |
-| `Replicas`| The number of instances that you want to run this source connector. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SourceConfig` | The map to a ConfigMap specifying the configuration of a source connector. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
+| `clusterName` | The Pulsar cluster of a source connector. |
+| `replicas`| The number of instances that you want to run this source connector. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sourceConfig` | The map to a ConfigMap specifying the configuration of a source connector. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
 
 ## Images
 
@@ -40,11 +40,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: <br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher. 
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: <br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher. 
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -54,7 +54,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -95,15 +95,15 @@ Function Mesh supports customizing the Pod running connectors. This table lists 
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |

--- a/versioned_docs/version-0.1.6/functions/function-crd.md
+++ b/versioned_docs/version-0.1.6/functions/function-crd.md
@@ -16,21 +16,21 @@ This table lists Pulsar Function configurations.
 | `classname` | The class name of a Pulsar Function. |
 | `tenant` | The tenant of a Pulsar Function. |
 | `namespace` | The namespace of a Pulsar Function. |
-| `ClusterName` | The Pulsar cluster of a Pulsar Function. |
-| `Replicas`| The number of instances that you want to run this Pulsar Function. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `Timeout` | The message timeout in milliseconds. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
-| `FuncConfig` | The map to a ConfigMap specifying the configuration of a Pulsar function. |
-| `LogTopic` | The topic to which the logs of a Pulsar Function are produced. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `RetainOrdering` | Function consumes and processes messages in order. |
-| `RetainKeyOrdering`| Configure whether to retain the key order of messages. |
-| `SubscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a Pulsar Function. |
+| `replicas`| The number of instances that you want to run this Pulsar Function. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `timeout` | The message timeout in milliseconds. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
+| `funcConfig` | The map to a ConfigMap specifying the configuration of a Pulsar function. |
+| `logTopic` | The topic to which the logs of a Pulsar Function are produced. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `retainOrdering` | Function consumes and processes messages in order. |
+| `retainKeyOrdering`| Configure whether to retain the key order of messages. |
+| `subscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -58,10 +58,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Output
 
@@ -69,11 +69,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: < br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher.
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: < br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher.
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -83,7 +83,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -126,15 +126,15 @@ Function Mesh supports customizing the Pod running function instance. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |

--- a/versioned_docs/version-0.1.6/releases/release-note-0-1-6.md
+++ b/versioned_docs/version-0.1.6/releases/release-note-0-1-6.md
@@ -24,6 +24,6 @@ In release v0.1.4, we introduced the Function Mesh Worker service, which ensures
 
 In this release, we expose the `serviceAccountName` option in the CRDs of Pulsar Functions and connectors. Therefore, users can run Pulsar Functions and connectors using the Function Mesh Worker service.
 
-## Fix the NPE that is generated when the `AutoAck` option is not set
+## Fix the NPE that is generated when the `autoAck` option is not set
 
-If the `AutoAck` option is not set in the CRDs of Pulsar Functions and connectors, a Null Pointer Exception (NPE) is generated when creating a function, connector (sink or source) using the pulsar-admin CLI tool. To fix this bug, we set the `AutoAck` option to `true` by default. Therefore, users can successfully create Pulsar Functions and connectors.
+If the `autoAck` option is not set in the CRDs of Pulsar Functions and connectors, a Null Pointer Exception (NPE) is generated when creating a function, connector (sink or source) using the pulsar-admin CLI tool. To fix this bug, we set the `autoAck` option to `true` by default. Therefore, users can successfully create Pulsar Functions and connectors.

--- a/versioned_docs/version-0.1.7/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.1.7/connectors/io-crd-config/sink-crd-config.md
@@ -15,20 +15,20 @@ This table lists sink configurations.
 | `classname` | The class name of a sink connector. |
 | `tenant` | The tenant of a sink connector. |
 | `namespace` | The Pulsar namespace of a sink connector. |
-| `ClusterName` | The Pulsar cluster of a sink connector. |
-| `Replicas`| The number of instances that you want to run this sink connector. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SinkConfig` | The sink connector configurations in YAML format.|
-| `Timeout` | The message timeout in milliseconds. |
-| `NegativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `RetainOrdering` | The sink connector consumes and processes messages in order. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
-| `SubscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a sink connector. |
+| `replicas`| The number of instances that you want to run this sink connector. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sinkConfig` | The sink connector configurations in YAML format.|
+| `timeout` | The message timeout in milliseconds. |
+| `negativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `retainOrdering` | The sink connector consumes and processes messages in order. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
+| `subscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -50,10 +50,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Resources
 
@@ -63,7 +63,7 @@ If the node where a Pod is running has enough of a resource available, it is pos
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -104,18 +104,18 @@ Function Mesh supports customizing the Pod running Pulsar connectors. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/versioned_docs/version-0.1.7/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.1.7/connectors/io-crd-config/source-crd-config.md
@@ -15,12 +15,12 @@ This table lists source configurations.
 | `classname` | The class name of a source connector. |
 | `tenant` | The tenant of a source connector. |
 | `namespace` | The Pulsar namespace of a source connector. |
-| `ClusterName` | The Pulsar cluster of a source connector. |
-| `Replicas`| The number of instances that you want to run this source connector. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SourceConfig` | The source connector configurations in YAML format. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `ForwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
+| `clusterName` | The Pulsar cluster of a source connector. |
+| `replicas`| The number of instances that you want to run this source connector. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sourceConfig` | The source connector configurations in YAML format. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
 
 ## Images
 
@@ -42,11 +42,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: <br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher. 
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: <br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher. 
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -56,7 +56,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -97,18 +97,18 @@ Function Mesh supports customizing the Pod running connectors. This table lists 
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/versioned_docs/version-0.1.7/functions/function-crd.md
+++ b/versioned_docs/version-0.1.7/functions/function-crd.md
@@ -16,22 +16,22 @@ This table lists Pulsar Function configurations.
 | `classname` | The class name of a Pulsar Function. |
 | `tenant` | The tenant of a Pulsar Function. |
 | `namespace` | The Pulsar namespace of a Pulsar Function. |
-| `ClusterName` | The Pulsar cluster of a Pulsar Function. |
-| `Replicas`| The number of instances that you want to run this Pulsar Function. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `Timeout` | The message timeout in milliseconds. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
-| `FuncConfig` | Pulsar Functions configurations in YAML format. |
-| `LogTopic` | The topic to which the logs of a Pulsar Function are produced. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `ForwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
-| `RetainOrdering` | Function consumes and processes messages in order. |
-| `RetainKeyOrdering`| Configure whether to retain the key order of messages. |
-| `SubscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a Pulsar Function. |
+| `replicas`| The number of instances that you want to run this Pulsar Function. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `timeout` | The message timeout in milliseconds. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
+| `funcConfig` | Pulsar Functions configurations in YAML format. |
+| `logTopic` | The topic to which the logs of a Pulsar Function are produced. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
+| `retainOrdering` | Function consumes and processes messages in order. |
+| `retainKeyOrdering`| Configure whether to retain the key order of messages. |
+| `subscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -59,10 +59,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Output
 
@@ -70,11 +70,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: < br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher.
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: < br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher.
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -84,7 +84,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -127,18 +127,18 @@ Function Mesh supports customizing the Pod running function instance. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in Pulsar Functions. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in Pulsar Functions. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/versioned_docs/version-0.1.7/releases/release-note-0-1-6.md
+++ b/versioned_docs/version-0.1.7/releases/release-note-0-1-6.md
@@ -24,6 +24,6 @@ In release v0.1.4, we introduced the Function Mesh Worker service, which ensures
 
 In this release, we expose the `serviceAccountName` option in the CRDs of Pulsar Functions and connectors. Therefore, users can run Pulsar Functions and connectors using the Function Mesh Worker service.
 
-## Fix the NPE that is generated when the `AutoAck` option is not set
+## Fix the NPE that is generated when the `autoAck` option is not set
 
-If the `AutoAck` option is not set in the CRDs of Pulsar Functions and connectors, a Null Pointer Exception (NPE) is generated when creating a function, connector (sink or source) using the pulsar-admin CLI tool. To fix this bug, we set the `AutoAck` option to `true` by default. Therefore, users can successfully create Pulsar Functions and connectors.
+If the `autoAck` option is not set in the CRDs of Pulsar Functions and connectors, a Null Pointer Exception (NPE) is generated when creating a function, connector (sink or source) using the pulsar-admin CLI tool. To fix this bug, we set the `autoAck` option to `true` by default. Therefore, users can successfully create Pulsar Functions and connectors.

--- a/versioned_docs/version-0.1.8/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.1.8/connectors/io-crd-config/sink-crd-config.md
@@ -15,20 +15,20 @@ This table lists sink configurations.
 | `classname` | The class name of a sink connector. |
 | `tenant` | The tenant of a sink connector. |
 | `namespace` | The Pulsar namespace of a sink connector. |
-| `ClusterName` | The Pulsar cluster of a sink connector. |
-| `Replicas`| The number of instances that you want to run this sink connector. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SinkConfig` | The sink connector configurations in YAML format.|
-| `Timeout` | The message timeout in milliseconds. |
-| `NegativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `RetainOrdering` | The sink connector consumes and processes messages in order. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
-| `SubscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a sink connector. |
+| `replicas`| The number of instances that you want to run this sink connector. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sinkConfig` | The sink connector configurations in YAML format.|
+| `timeout` | The message timeout in milliseconds. |
+| `negativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `retainOrdering` | The sink connector consumes and processes messages in order. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
+| `subscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -50,10 +50,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Resources
 
@@ -63,7 +63,7 @@ If the node where a Pod is running has enough of a resource available, it is pos
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -104,18 +104,18 @@ Function Mesh supports customizing the Pod running Pulsar connectors. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/versioned_docs/version-0.1.8/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.1.8/connectors/io-crd-config/source-crd-config.md
@@ -15,12 +15,12 @@ This table lists source configurations.
 | `classname` | The class name of a source connector. |
 | `tenant` | The tenant of a source connector. |
 | `namespace` | The Pulsar namespace of a source connector. |
-| `ClusterName` | The Pulsar cluster of a source connector. |
-| `Replicas`| The number of instances that you want to run this source connector. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SourceConfig` | The source connector configurations in YAML format. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `ForwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
+| `clusterName` | The Pulsar cluster of a source connector. |
+| `replicas`| The number of instances that you want to run this source connector. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sourceConfig` | The source connector configurations in YAML format. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
 
 ## Images
 
@@ -42,11 +42,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: <br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher. 
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: <br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher. 
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -56,7 +56,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -97,18 +97,18 @@ Function Mesh supports customizing the Pod running connectors. This table lists 
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/versioned_docs/version-0.1.8/functions/function-crd.md
+++ b/versioned_docs/version-0.1.8/functions/function-crd.md
@@ -16,22 +16,22 @@ This table lists Pulsar Function configurations.
 | `classname` | The class name of a Pulsar Function. |
 | `tenant` | The tenant of a Pulsar Function. |
 | `namespace` | The Pulsar namespace of a Pulsar Function. |
-| `ClusterName` | The Pulsar cluster of a Pulsar Function. |
-| `Replicas`| The number of instances that you want to run this Pulsar Function. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `Timeout` | The message timeout in milliseconds. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
-| `FuncConfig` | Pulsar Functions configurations in YAML format. |
-| `LogTopic` | The topic to which the logs of a Pulsar Function are produced. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `ForwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
-| `RetainOrdering` | Function consumes and processes messages in order. |
-| `RetainKeyOrdering`| Configure whether to retain the key order of messages. |
-| `SubscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a Pulsar Function. |
+| `replicas`| The number of instances that you want to run this Pulsar Function. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `timeout` | The message timeout in milliseconds. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
+| `funcConfig` | Pulsar Functions configurations in YAML format. |
+| `logTopic` | The topic to which the logs of a Pulsar Function are produced. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
+| `retainOrdering` | Function consumes and processes messages in order. |
+| `retainKeyOrdering`| Configure whether to retain the key order of messages. |
+| `subscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -59,10 +59,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Output
 
@@ -70,11 +70,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: < br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher.
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: < br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher.
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -84,7 +84,7 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -127,18 +127,18 @@ Function Mesh supports customizing the Pod running function instance. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in Pulsar Functions. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in Pulsar Functions. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/versioned_docs/version-0.1.8/releases/release-note-0-1-6.md
+++ b/versioned_docs/version-0.1.8/releases/release-note-0-1-6.md
@@ -24,6 +24,6 @@ In release v0.1.4, we introduced the Function Mesh Worker service, which ensures
 
 In this release, we expose the `serviceAccountName` option in the CRDs of Pulsar Functions and connectors. Therefore, users can run Pulsar Functions and connectors using the Function Mesh Worker service.
 
-## Fix the NPE that is generated when the `AutoAck` option is not set
+## Fix the NPE that is generated when the `autoAck` option is not set
 
-If the `AutoAck` option is not set in the CRDs of Pulsar Functions and connectors, a Null Pointer Exception (NPE) is generated when creating a function, connector (sink or source) using the pulsar-admin CLI tool. To fix this bug, we set the `AutoAck` option to `true` by default. Therefore, users can successfully create Pulsar Functions and connectors.
+If the `autoAck` option is not set in the CRDs of Pulsar Functions and connectors, a Null Pointer Exception (NPE) is generated when creating a function, connector (sink or source) using the pulsar-admin CLI tool. To fix this bug, we set the `autoAck` option to `true` by default. Therefore, users can successfully create Pulsar Functions and connectors.

--- a/versioned_docs/version-0.1.9/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.1.9/connectors/io-crd-config/sink-crd-config.md
@@ -15,20 +15,20 @@ This table lists sink configurations.
 | `classname` | The class name of a sink connector. |
 | `tenant` | The tenant of a sink connector. |
 | `namespace` | The Pulsar namespace of a sink connector. |
-| `ClusterName` | The Pulsar cluster of a sink connector. |
-| `Replicas`| The number of instances that you want to run this sink connector. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SinkConfig` | The sink connector configurations in YAML format.|
-| `Timeout` | The message timeout in milliseconds. |
-| `NegativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `RetainOrdering` | The sink connector consumes and processes messages in order. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
-| `SubscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a sink connector. |
+| `replicas`| The number of instances that you want to run this sink connector. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sinkConfig` | The sink connector configurations in YAML format.|
+| `timeout` | The message timeout in milliseconds. |
+| `negativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the sink connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `retainOrdering` | The sink connector consumes and processes messages in order. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. |
+| `subscriptionName` | The subscription name of the sink connector if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -50,10 +50,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the connector. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the connector. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the connector. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the connector. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. <br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Resources
 
@@ -63,9 +63,9 @@ If the node where a Pod is running has enough of a resource available, it is pos
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
+Function Mesh provides the `secretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
 
-The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
+The `secretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
 
 | Field | Description |
 | --- | --- |
@@ -85,7 +85,7 @@ metadata:
 type: Opaque
 ```
 
-To use it in Pulsar Functions in a secure way, you can define the `SecretsMap` in the Custom Resource:
+To use it in Pulsar Functions in a secure way, you can define the `secretsMap` in the Custom Resource:
 
 ```yaml
 secretsMap:
@@ -101,7 +101,7 @@ Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("u
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -142,18 +142,18 @@ Function Mesh supports customizing the Pod running Pulsar connectors. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | The initialization containers belonging to a Pod. A typical use case could be using an initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/versioned_docs/version-0.1.9/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.1.9/connectors/io-crd-config/source-crd-config.md
@@ -15,12 +15,12 @@ This table lists source configurations.
 | `classname` | The class name of a source connector. |
 | `tenant` | The tenant of a source connector. |
 | `namespace` | The Pulsar namespace of a source connector. |
-| `ClusterName` | The Pulsar cluster of a source connector. |
-| `Replicas`| The number of instances that you want to run this source connector. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `SourceConfig` | The source connector configurations in YAML format. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `ForwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
+| `clusterName` | The Pulsar cluster of a source connector. |
+| `replicas`| The number of instances that you want to run this source connector. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `sourceConfig` | The source connector configurations in YAML format. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
 
 ## Images
 
@@ -42,11 +42,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: <br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher. 
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: <br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher. 
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -56,9 +56,9 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
+Function Mesh provides the `secretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
 
-The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
+The `secretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
 
 | Field | Description |
 | --- | --- |
@@ -78,7 +78,7 @@ metadata:
 type: Opaque
 ```
 
-To use it in Pulsar Functions in a secure way, you can define the `SecretsMap` in the Custom Resource:
+To use it in Pulsar Functions in a secure way, you can define the `secretsMap` in the Custom Resource:
 
 ```yaml
 secretsMap:
@@ -94,7 +94,7 @@ Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("u
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -135,18 +135,18 @@ Function Mesh supports customizing the Pod running connectors. This table lists 
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/versioned_docs/version-0.1.9/functions/function-crd.md
+++ b/versioned_docs/version-0.1.9/functions/function-crd.md
@@ -16,22 +16,22 @@ This table lists Pulsar Function configurations.
 | `classname` | The class name of a Pulsar Function. |
 | `tenant` | The tenant of a Pulsar Function. |
 | `namespace` | The Pulsar namespace of a Pulsar Function. |
-| `ClusterName` | The Pulsar cluster of a Pulsar Function. |
-| `Replicas`| The number of instances that you want to run this Pulsar Function. By default, the `Replicas` is set to `1`. |
-| `MaxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
-| `Timeout` | The message timeout in milliseconds. |
-| `DeadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
-| `FuncConfig` | Pulsar Functions configurations in YAML format. |
-| `LogTopic` | The topic to which the logs of a Pulsar Function are produced. |
-| `AutoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
-| `MaxMessageRetry` | How many times to process a message before giving up. |
-| `ProcessingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `ATLEAST_ONCE`, `ATMOST_ONCE`, `EFFECTIVELY_ONCE`.|
-| `ForwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
-| `RetainOrdering` | Function consumes and processes messages in order. |
-| `RetainKeyOrdering`| Configure whether to retain the key order of messages. |
-| `SubscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
-| `CleanupSubscription` | Configure whether to clean up subscriptions. |
-| `SubscriptionPosition` | The subscription position. |
+| `clusterName` | The Pulsar cluster of a Pulsar Function. |
+| `replicas`| The number of instances that you want to run this Pulsar Function. By default, the `replicas` is set to `1`. |
+| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `timeout` | The message timeout in milliseconds. |
+| `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
+| `funcConfig` | Pulsar Functions configurations in YAML format. |
+| `logTopic` | The topic to which the logs of a Pulsar Function are produced. |
+| `autoAck` | Whether or not the framework acknowledges messages automatically. This field is required. You can set it to `true` or `false`.|
+| `maxMessageRetry` | How many times to process a message before giving up. |
+| `processingGuarantee` | The processing guarantees (delivery semantics) applied to the function. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
+| `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
+| `retainOrdering` | Function consumes and processes messages in order. |
+| `retainKeyOrdering`| Configure whether to retain the key order of messages. |
+| `subscriptionName` | Pulsar Functions’ subscription name if you want a specific subscription-name for the input-topic consumer. |
+| `cleanupSubscription` | Configure whether to clean up subscriptions. |
+| `subscriptionPosition` | The subscription position. |
 
 ## Images
 
@@ -59,10 +59,10 @@ The input topics of a Pulsar Function. The following table lists options availab
 
 | Field | Description |
 | --- | --- |
-| `Topics` | The configuration of the topic from which messages are fetched. |
-| `CustomSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
-| `CustomSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
-| `SourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `CryptoConfig`: cryptography configurations of the consumer. |
+| `topics` | The configuration of the topic from which messages are fetched. |
+| `customSerdeSources` | The map of input topics to SerDe class names (as a JSON string). |
+| `customSchemaSources` | The map of input topics to Schema class names (as a JSON string). |
+| `sourceSpecs` | The map of source specifications to consumer specifications. Consumer specifications include these options: <br />- `SchemaType`: the built-in schema type or custom schema class name to be used for messages fetched by the function. <br />- `SerdeClassName`: the SerDe class to be used for messages fetched by the function. <br />- `IsRegexPattern`: configure whether the input topic adopts a Regex pattern. <br />- `SchemaProperties`: the schema properties for messages fetched by the function. <br />- `ConsumerProperties`: the consumer properties for messages fetched by the function. <br />- `ReceiverQueueSize`: the size of the consumer receive queue. br /> - `cryptoConfig`: cryptography configurations of the consumer. |
 
 ## Output
 
@@ -70,11 +70,11 @@ The output topics of a Pulsar Function. This table lists options available for t
 
 |Name | Description |
 | --- | --- |
-| `Topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
-| `SinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
-| `SinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
-| `ProducerConf` | The producer specifications. Available options: < br />- `MaxPendingMessages`: the maximum number of pending messages. <br />- `MaxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `UseThreadLocalProducers`: configure whether the producer uses a thread. <br />- `CryptoConfig`: cryptography configurations of the producer. <br />- `BatchBuilder`: support key-based batcher.
-| `CustomSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
+| `topics` | The output topic of a Pulsar Function (If none is specified, no output is written). | 
+| `sinkSerdeClassName` | The map of output topics to SerDe class names (as a JSON string). |
+| `sinkSchemaType` | The built-in schema type or custom schema class name to be used for messages sent by the function.|
+| `producerConf` | The producer specifications. Available options: < br />- `maxPendingMessages`: the maximum number of pending messages. <br />- `maxPendingMessagesAcrossPartitions`: the maximum number of pending messages across partitions. <br />- `useThreadLocalProducers`: configure whether the producer uses a thread. <br />- `cryptoConfig`: cryptography configurations of the producer. <br />- `batchBuilder`: support key-based batcher.
+| `customSchemaSinks` | The map of output topics to Schema class names (as a JSON string). |
 
 ## Resources
 
@@ -84,9 +84,9 @@ If the node where a Pod is running has enough of a resource available, it's poss
 
 ## Secrets
 
-Function Mesh provides the `SecretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
+Function Mesh provides the `secretsMap` field for Function, Source, and Sink in the CRD definition. You can refer to the created secrets under the same namespace and the controller can include those referred secrets. The secrets are provide by `EnvironmentBasedSecretsProvider`, which can be used by `context.getSecret()` in Pulsar functions and connectors.
 
-The `SecretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
+The `secretsMap` field is defined as a `Map` struct with `String` keys and `SecretReference` values. The key indicates the environment value in the container, and the `SecretReference` is defined as below.
 
 | Field | Description |
 | --- | --- |
@@ -106,7 +106,7 @@ metadata:
 type: Opaque
 ```
 
-To use it in Pulsar Functions in a secure way, you can define the `SecretsMap` in the Custom Resource:
+To use it in Pulsar Functions in a secure way, you can define the `secretsMap` in the Custom Resource:
 
 ```yaml
 secretsMap:
@@ -122,7 +122,7 @@ Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("u
 
 ## Authentication
 
-Function Mesh provides the `TLSSecret` and `AuthSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsSecret` and `authSecret` fields for Function, Source and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
 
 - TLS Secret
 
@@ -165,18 +165,18 @@ Function Mesh supports customizing the Pod running function instance. This table
 
 | Field | Description |
 | --- | --- |
-| `Labels` | Specify labels attached to a Pod. |
-| `NodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
-| `Affinity` | Specify the scheduling constraints of a Pod. |
-| `Tolerations` | Specify the tolerations of a Pod. |
-| `Annotations`| Specify the annotations attached to a Pod. |
-| `SecurityContext` | Specify the security context for a Pod. |
-| `TerminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
-| `Volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
-| `ImagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
-| `ServiceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
-| `InitContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
-| `Sidecars` | Sidecar containers run together with the main function container in a Pod. |
-| `BuiltinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `BuiltinAutoscaler` field, you do not need to configure the `AutoScalingMetrics` and `AutoScalingBehavior` options and vice versa.|
-| `AutoScalingMetrics` | Specify how to scale based on customized metrics defined in Pulsar Functions. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
-| `AutoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |
+| `labels` | Specify labels attached to a Pod. |
+| `nodeSelector` | Specify a map of key-value pairs. For a Pod running on a node, the node must have each of the indicated key-value pairs as labels. |
+| `affinity` | Specify the scheduling constraints of a Pod. |
+| `tolerations` | Specify the tolerations of a Pod. |
+| `annotations`| Specify the annotations attached to a Pod. |
+| `securityContext` | Specify the security context for a Pod. |
+| `terminationGracePeriodSeconds` | It is the amount of time that Kubernetes gives for a Pod before terminating it. |
+| `volumes` | It is a list of volumes that can be mounted by containers belonging to a Pod. |
+| `imagePullSecrets` | It is an optional list of references to secrets in the same namespace for pulling any of the images used by a Pod. |
+| `serviceAccountName` | Specify the name of the service account which is used to run Pulsar Functions or connectors in the Function Mesh Worker service.|
+| `initContainers` | Initialization containers belonging to a Pod. A typical use case could be using an Initialization container to download a remote JAR to a local path. |
+| `sidecars` | Sidecar containers run together with the main function container in a Pod. |
+| `builtinAutoscaler` | Specify the built-in autoscaling rules. <br /> - CPU-based autoscaling: auto-scale the number of Pods based on the CPU usage (80%, 50%, or 20%). <br />- Memory-based autoscaling: auto-scale the number of Pods based on the memory usage (80%, 50%, or 20%). <br /> If you configure the `builtinAutoscaler` field, you do not need to configure the `autoScalingMetrics` and `autoScalingBehavior` options and vice versa.|
+| `autoScalingMetrics` | Specify how to scale based on customized metrics defined in Pulsar Functions. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling). |
+| `autoScalingBehavior` | Configure the scaling behavior of the target in both up and down directions (`scaleUp` and `scaleDown` fields respectively). If not specified, the default Kubernetes scaling behaviors are adopted. For details, see [HorizontalPodAutoscalerBehavior v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#horizontalpodautoscalerbehavior-v2beta2-autoscaling). |

--- a/versioned_docs/version-0.1.9/releases/release-note-0-1-6.md
+++ b/versioned_docs/version-0.1.9/releases/release-note-0-1-6.md
@@ -24,6 +24,6 @@ In release v0.1.4, we introduced the Function Mesh Worker service, which ensures
 
 In this release, we expose the `serviceAccountName` option in the CRDs of Pulsar Functions and connectors. Therefore, users can run Pulsar Functions and connectors using the Function Mesh Worker service.
 
-## Fix the NPE that is generated when the `AutoAck` option is not set
+## Fix the NPE that is generated when the `autoAck` option is not set
 
-If the `AutoAck` option is not set in the CRDs of Pulsar Functions and connectors, a Null Pointer Exception (NPE) is generated when creating a function, connector (sink or source) using the pulsar-admin CLI tool. To fix this bug, we set the `AutoAck` option to `true` by default. Therefore, users can successfully create Pulsar Functions and connectors.
+If the `autoAck` option is not set in the CRDs of Pulsar Functions and connectors, a Null Pointer Exception (NPE) is generated when creating a function, connector (sink or source) using the pulsar-admin CLI tool. To fix this bug, we set the `autoAck` option to `true` by default. Therefore, users can successfully create Pulsar Functions and connectors.


### PR DESCRIPTION
The first letter of the field in Function/Sink/Source CRDs should be a lower-case letter. Therefore, update docs for all releases.

