### PR TITLE
[FM v0.3.0]-- Support specifying objects as unmanaged objects

### DIFF
--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -34,7 +34,7 @@ This table lists sink configurations.
 
 In Kubernetes, an annotation defines an unstructured Key Value Map (KVM) that can be set by external tools to store and retrieve metadata. `annotations` must be a map of string keys and string values. Annotation values must pass Kubernetes annotations validation. For details, see [Kubernetes documentation on Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set).
 
-This example shows how to use an annotation to make an object unmanaged. Therefore, the Controller can skip unmanaged objects when checking for the annotation in the reconciliation loop.
+This example shows how to use an annotation to make an object unmanaged. Therefore, the Controller will skip reconciling unmanaged objects in reconciliation loop.
 
 ```yaml
 apiVersion: compute.functionmesh.io/v1alpha1

--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -30,6 +30,20 @@ This table lists sink configurations.
 | `cleanupSubscription` | Configure whether to clean up subscriptions. |
 | `subscriptionPosition` | The subscription position. |
 
+## Annotations
+
+In Kubernetes, an annotation defines an unstructured Key Value Map (KVM) that can be set by external tools to store and retrieve metadata. `annotations` must be a map of string keys and string values. Annotation values must pass Kubernetes annotations validation. For details, see [Kubernetes documentation on Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set).
+
+This example shows how to use an annotation to make an object unmanaged. Therefore, the Controller can skip unmanaged objects when checking for the annotation in the reconciliation loop.
+
+```yaml
+apiVersion: compute.functionmesh.io/v1alpha1
+kind: Sink
+metadata:
+  annotations:
+    compute.functionmesh.io/managed: "false"
+```
+
 ## Images
 
 This section describes image options available for Pulsar sink CRDs.

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -26,7 +26,7 @@ This table lists source configurations.
 
 In Kubernetes, an annotation defines an unstructured Key Value Map (KVM) that can be set by external tools to store and retrieve metadata. `annotations` must be a map of string keys and string values. Annotation values must pass Kubernetes annotations validation. For details, see [Kubernetes documentation on Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set).
 
-This example shows how to use an annotation to make an object unmanaged. Therefore, the Controller can skip unmanaged objects when checking for the annotation in the reconciliation loop.
+This example shows how to use an annotation to make an object unmanaged. Therefore, the Controller will skip reconciling unmanaged objects in reconciliation loop.
 
 ```yaml
 apiVersion: compute.functionmesh.io/v1alpha1

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -22,6 +22,20 @@ This table lists source configurations.
 | `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
 | `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
 
+## Annotations
+
+In Kubernetes, an annotation defines an unstructured Key Value Map (KVM) that can be set by external tools to store and retrieve metadata. `annotations` must be a map of string keys and string values. Annotation values must pass Kubernetes annotations validation. For details, see [Kubernetes documentation on Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set).
+
+This example shows how to use an annotation to make an object unmanaged. Therefore, the Controller can skip unmanaged objects when checking for the annotation in the reconciliation loop.
+
+```yaml
+apiVersion: compute.functionmesh.io/v1alpha1
+kind: Source
+metadata:
+  annotations:
+    compute.functionmesh.io/managed: "false"
+```
+
 ## Images
 
 This section describes image options available for Pulsar source CRDs.

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -37,7 +37,7 @@ This table lists Pulsar Function configurations.
 
 In Kubernetes, an annotation defines an unstructured Key Value Map (KVM) that can be set by external tools to store and retrieve metadata. `annotations` must be a map of string keys and string values. Annotation values must pass Kubernetes annotations validation. For details, see [Kubernetes documentation on Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set).
 
-This example shows how to use an annotation to make an object unmanaged. Therefore, the Controller can skip unmanaged objects when checking for the annotation in the reconciliation loop.
+This example shows how to use an annotation to make an object unmanaged. Therefore, the Controller will skip reconciling unmanaged objects in reconciliation loop.
 
 ```yaml
 apiVersion: compute.functionmesh.io/v1alpha1

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -33,6 +33,20 @@ This table lists Pulsar Function configurations.
 | `cleanupSubscription` | Configure whether to clean up subscriptions. |
 | `subscriptionPosition` | The subscription position. |
 
+## Annotations
+
+In Kubernetes, an annotation defines an unstructured Key Value Map (KVM) that can be set by external tools to store and retrieve metadata. `annotations` must be a map of string keys and string values. Annotation values must pass Kubernetes annotations validation. For details, see [Kubernetes documentation on Annotations](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set).
+
+This example shows how to use an annotation to make an object unmanaged. Therefore, the Controller can skip unmanaged objects when checking for the annotation in the reconciliation loop.
+
+```yaml
+apiVersion: compute.functionmesh.io/v1alpha1
+kind: Function
+metadata:
+  annotations:
+    compute.functionmesh.io/managed: "false"
+```
+
 ## Images
 
 This section describes image options available for Pulsar Function, source, sink and Function Mesh CRDs.


### PR DESCRIPTION
### Motivation
The [Code PR #377](https://github.com/streamnative/function-mesh/pull/377) introduces an annotation, which can be used to specify an object as unmanaged. Therefore, update the doc accordingly.

### Modification:

Add a section "Annotations" in Function, Source, and Sink CRD overview docs.

### Affected releases:
Function Mesh v0.3.0
