### PR TITLE
[FM v0.6.0]--Support log rotation policy

### DIFF
--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -191,6 +191,21 @@ Function Mesh supports running Pulsar connectors in Java.
 | `jarLocation` | Path to the JAR file for the connector.|
 | `extraDependenciesDir` | It specifies the dependent directory for the JAR package. |
 
+## Log rotation policies
+
+With more and more logs being written to the log file, the log file grows in size. Therefore, Function Mesh supports log rotation to avoid large files that could create issues when opening them. You can set the log rotation policies based on the time or the log file size.
+
+| Field | Description |
+| --- | --- |
+| `TimedPolicyWithDaily` | Rotate the log file daily.   |
+| `TimedPolicyWithWeekly` | Rotate the log file weekly.   |
+| `TimedPolicyWithMonthly` | Rotate the log file monthly. |
+| `SizedPolicyWith10MB` | Rotate the log file at every 10 MB. |
+| `SizedPolicyWith50MB` | Rotate the log file at every 50 MB.  |
+| `SizedPolicyWith100MB` | Rotate the log file at every 100 MB.  |
+
+For details about how to set a log rotation policy, see [set log rotation policies](/functions/produce-function-log.md#set-log-rotation-policies).
+
 ## Cluster location
 
 In Function Mesh, the Pulsar cluster is defined through a ConfigMap. Pods can consume ConfigMaps as environment variables in a volume. The Pulsar cluster ConfigMap defines the Pulsar cluster URLs.

--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -170,7 +170,7 @@ Function Mesh provides the `tlsConfig`, `tlsSecret`, `authSecret`, `authConfig` 
       </tr>
       <tr>
         <td><code>scope</code></td>
-        <td>The scope of an access request. For more information, see [access token scope](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).</td>
+        <td>The scope of an access request. For more information, see <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-3.3">access token scope</a>.</td>
       </tr>
       <tr>
         <td><code>keySecretName</code></td>

--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -191,21 +191,6 @@ Function Mesh supports running Pulsar connectors in Java.
 | `jarLocation` | Path to the JAR file for the connector.|
 | `extraDependenciesDir` | It specifies the dependent directory for the JAR package. |
 
-## Log rotation policies
-
-With more and more logs being written to the log file, the log file grows in size. Therefore, Function Mesh supports log rotation to avoid large files that could create issues when opening them. You can set the log rotation policies based on the time or the log file size.
-
-| Field | Description |
-| --- | --- |
-| `TimedPolicyWithDaily` | Rotate the log file daily.   |
-| `TimedPolicyWithWeekly` | Rotate the log file weekly.   |
-| `TimedPolicyWithMonthly` | Rotate the log file monthly. |
-| `SizedPolicyWith10MB` | Rotate the log file at every 10 MB. |
-| `SizedPolicyWith50MB` | Rotate the log file at every 50 MB.  |
-| `SizedPolicyWith100MB` | Rotate the log file at every 100 MB.  |
-
-For details about how to set a log rotation policy, see [set log rotation policies](/functions/produce-function-log.md#set-log-rotation-policies).
-
 ## Cluster location
 
 In Function Mesh, the Pulsar cluster is defined through a ConfigMap. Pods can consume ConfigMaps as environment variables in a volume. The Pulsar cluster ConfigMap defines the Pulsar cluster URLs.

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -163,7 +163,7 @@ Function Mesh provides the `tlsConfig`, `tlsSecret`, `authSecret`, `authConfig` 
       </tr>
       <tr>
         <td><code>scope</code></td>
-        <td>The scope of an access request. For more information, see [access token scope](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).</td>
+        <td>The scope of an access request. For more information, see <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-3.3">access token scope</a>.</td>
       </tr>
       <tr>
         <td><code>keySecretName</code></td>

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -184,21 +184,6 @@ Function Mesh supports running Pulsar connectors in Java.
 | `jarLocation` | Path to the JAR file for the connector. |
 | `extraDependenciesDir` | It specifies the dependent directory for the JAR package. |
 
-## Log rotation policies
-
-With more and more logs being written to the log file, the log file grows in size. Therefore, Function Mesh supports log rotation to avoid large files that could create issues when opening them. You can set the log rotation policies based on the time or the log file size.
-
-| Field | Description |
-| --- | --- |
-| `TimedPolicyWithDaily` | Rotate the log file daily.   |
-| `TimedPolicyWithWeekly` | Rotate the log file weekly.   |
-| `TimedPolicyWithMonthly` | Rotate the log file monthly. |
-| `SizedPolicyWith10MB` | Rotate the log file at every 10 MB. |
-| `SizedPolicyWith50MB` | Rotate the log file at every 50 MB.  |
-| `SizedPolicyWith100MB` | Rotate the log file at every 100 MB.  |
-
-For details about how to set a log rotation policy, see [set log rotation policies](/functions/produce-function-log.md#set-log-rotation-policies).
-
 ## Cluster location
 
 In Function Mesh, the Pulsar cluster is defined through a ConfigMap. Pods can consume ConfigMaps as environment variables in a volume. The Pulsar cluster ConfigMap defines the Pulsar cluster URLs.

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -184,6 +184,21 @@ Function Mesh supports running Pulsar connectors in Java.
 | `jarLocation` | Path to the JAR file for the connector. |
 | `extraDependenciesDir` | It specifies the dependent directory for the JAR package. |
 
+## Log rotation policies
+
+With more and more logs being written to the log file, the log file grows in size. Therefore, Function Mesh supports log rotation to avoid large files that could create issues when opening them. You can set the log rotation policies based on the time or the log file size.
+
+| Field | Description |
+| --- | --- |
+| `TimedPolicyWithDaily` | Rotate the log file daily.   |
+| `TimedPolicyWithWeekly` | Rotate the log file weekly.   |
+| `TimedPolicyWithMonthly` | Rotate the log file monthly. |
+| `SizedPolicyWith10MB` | Rotate the log file at every 10 MB. |
+| `SizedPolicyWith50MB` | Rotate the log file at every 50 MB.  |
+| `SizedPolicyWith100MB` | Rotate the log file at every 100 MB.  |
+
+For details about how to set a log rotation policy, see [set log rotation policies](/functions/produce-function-log.md#set-log-rotation-policies).
+
 ## Cluster location
 
 In Function Mesh, the Pulsar cluster is defined through a ConfigMap. Pods can consume ConfigMaps as environment variables in a volume. The Pulsar cluster ConfigMap defines the Pulsar cluster URLs.

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -203,7 +203,7 @@ Function Mesh provides the `tlsConfig`, `tlsSecret`, `authSecret`, `authConfig` 
       </tr>
       <tr>
         <td><code>scope</code></td>
-        <td>The scope of an access request. For more information, see [access token scope](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).</td>
+        <td>The scope of an access request. For more information, see <a href="https://datatracker.ietf.org/doc/html/rfc6749#section-3.3">access token scope</a>.</td>
       </tr>
       <tr>
         <td><code>keySecretName</code></td>

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -241,11 +241,26 @@ By default, the log level for Pulsar functions is `info`. Function Mesh supports
 | `debug` | The logs that are used for interactive investigation during development. These logs primarily contain information useful for debugging and have no long-term value. | ✔ | ✔ |  ✔ |
 | `warn` | The logs that highlight an abnormal or unexpected event in the function, but do not cause the function to stop. | ✔ | ✔ |  ✔ |
 | `error` | The logs that highlight when the function is stopped due to a failure. These indicate a failure in the current activity, not an application-wide failure. | ✔ | ✔ |  ✔ |
-| `fatal` | The logs that contain fatal errors. It indicates that the function is unusable | ✔ | ✔ |  ✔ |
+| `fatal` | The logs that contain fatal errors. It indicates that the function is unusable. | ✔ | ✔ |  ✔ |
 | `all` | All events are logged. | ✔ | ✗ | ✗ |
 | `panic` | It indicates the function is in panic. | ✗ | ✗ | ✔ |
 
 For details about how to set log levels and produce logs for Pulsar functions, see [produce function logs](/functions/produce-function-log.md).
+
+## Log rotation policies
+
+With more and more logs being written to the log file, the log file grows in size. Therefore, Function Mesh supports log rotation to avoid large files that could create issues when opening them. You can set the log rotation policies based on the time or the log file size.
+
+| Field | Description |
+| --- | --- |
+| `TimedPolicyWithDaily` | Rotate the log file daily.   |
+| `TimedPolicyWithWeekly` | Rotate the log file weekly.   |
+| `TimedPolicyWithMonthly` | Rotate the log file monthly. |
+| `SizedPolicyWith10MB` | Rotate the log file at every 10 MB. |
+| `SizedPolicyWith50MB` | Rotate the log file at every 50 MB.  |
+| `SizedPolicyWith100MB` | Rotate the log file at every 100 MB.  |
+
+For details about how to set a log rotation policy, see [set log rotation policies](/functions/produce-function-log.md#set-log-rotation-policies).
 
 ## Cluster location
 

--- a/docs/functions/produce-function-log.md
+++ b/docs/functions/produce-function-log.md
@@ -104,6 +104,30 @@ data:
 - [7] `additivity`: indicates whether log messages will be duplicated if multiple `<Logger>` entries overlap. If it is set to `false`, it means to prevent duplication of log messages when one or more `<Logger>` entries contain classes or modules that overlap.
 - [8] `AppenderRef`: allows you to output the log to a destination that is specified in the `Appenders` section.
 
+## Set log rotation policies
+
+With more and more logs being written to the log file, the log file grows in size. Therefore, Function Mesh supports log rotation to avoid large files that could create issues when opening them. After being rotated, the original logs are compressed into a ZIP file and new logs are continuously written to the log file. 
+
+You can still access the log data within these ZIP files, but you need to extract the file content to view it. Compressed files reduce their size and save disk space, and they take up less space when you archive or back up your logs to another location.
+
+This example shows how to set the log rotation policy to `TimedPolicyWithDaily` by using the `spec.log.rotatePolicy` option.
+
+```yaml
+apiVersion: compute.functionmesh.io/v1alpha1
+kind: Function
+metadata:
+  name: function-sample
+  namespace: default
+spec:
+  java:                                                 --- [1]
+    log:                                                --- [2]
+      rotatePolicy: "TimedPolicyWithDaily"              --- [3]        
+```
+
+- [1] `java`: represents the runtime with a specific programming language. Currently, available options include the Java runtime, the Python runtime, and the Go runtime.
+- [2] `log`: represents the log configurations for a Pulsar function.
+- [3] `rotatePolicy`: represents the [log rotation policies](/functions/function-crd.md#log-rotation-policies) available for a Pulsar function.
+
 ## Produce logs for Pulsar functions
 
 This section describes how to produce logs for Pulsar functions.

--- a/docs/functions/produce-function-log.md
+++ b/docs/functions/produce-function-log.md
@@ -106,11 +106,11 @@ data:
 
 ## Set log rotation policies
 
-With more and more logs being written to the log file, the log file grows in size. Therefore, Function Mesh supports log rotation to avoid large files that could create issues when opening them. After being rotated, the original logs are compressed into a ZIP file and new logs are continuously written to the log file. 
+With more and more logs being written to the log file, the log file grows in size. Therefore, Function Mesh supports log rotation to avoid large files that could create issues when opening them. After being rotated, the original logs are compressed into a file and new logs are continuously written to the log file. 
 
-You can still access the log data within these ZIP files, but you need to extract the file content to view it. Compressed files reduce their size and save disk space, and they take up less space when you archive or back up your logs to another location.
+You can still access the log data within these compressed files, but you need to extract the file content to view it. Compressed files reduce their size and save disk space, and they take up less space when you archive or back up your logs to another location.
 
-This example shows how to set the log rotation policy to `TimedPolicyWithDaily` by using the `spec.log.rotatePolicy` option.
+This example shows how to set the log rotation policy to `TimedPolicyWithDaily` by using the `spec.<runtime>.log.rotatePolicy` option.
 
 ```yaml
 apiVersion: compute.functionmesh.io/v1alpha1


### PR DESCRIPTION
### Motivations

Function Mesh v0.6.0 support setting log rotation policies ([code PR#463](https://github.com/streamnative/function-mesh/pull/463)), therefore add docs accordingly.

### Modifications

- Update Functions/Sources/Sinks CRD configurations doc
- Add a new section "Set log rotation policies" in the "Produce function logs" document