### PR TITLE
[FM v0.6.0]--Update docs for HPA autoscaling enhancement

### DIFF
--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -16,8 +16,8 @@ This table lists sink configurations.
 | `tenant` | The tenant of a sink connector. |
 | `namespace` | The Pulsar namespace of a sink connector. |
 | `clusterName` | The Pulsar cluster of a sink connector. |
-| `replicas`| The number of instances that you want to run for this sink connector. If no value is set, the system will set `1` to it. |
-| `minReplicas`| The minimum number of instances that you want to run for this sink connector. If no value is set, the system will set `1` to it. When HPA auto-scaling is enabled, the HPA controller scales up / down the Pods based on the values of the `minReplicas` and `maxReplicas` options. The number of the Pods should be greater than the value of the `minReplicas` while be smaller than the value of the `maxReplicas`.  |
+| `replicas`| The number of instances that you want to run for this sink connector. If no value is set, the system will set it to `1`. |
+| `minReplicas`| The minimum number of instances that you want to run for this sink connector. If no value is set, the system will set it to `1`. When HPA auto-scaling is enabled, the HPA controller scales the Pods up / down based on the values of the `minReplicas` and `maxReplicas` options. The number of the Pods should be greater than the value of the `minReplicas` and be smaller than the value of the `maxReplicas`.  |
 | `maxReplicas`| The maximum number of instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
 | `sinkConfig` | The sink connector configurations in YAML format.|
 | `timeout` | The message timeout in milliseconds. |

--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -16,8 +16,9 @@ This table lists sink configurations.
 | `tenant` | The tenant of a sink connector. |
 | `namespace` | The Pulsar namespace of a sink connector. |
 | `clusterName` | The Pulsar cluster of a sink connector. |
-| `replicas`| The number of instances that you want to run this sink connector. By default, the `replicas` is set to `1`. |
-| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `replicas`| The number of instances that you want to run for this sink connector. If no value is set, the system will set `1` to it. |
+| `minReplicas`| The minimum number of instances that you want to run for this sink connector. If no value is set, the system will set `1` to it. When HPA auto-scaling is enabled, the HPA controller scales up / down the Pods based on the values of the `minReplicas` and `maxReplicas` options. The number of the Pods should be greater than the value of the `minReplicas` while be smaller than the value of the `maxReplicas`.  |
+| `maxReplicas`| The maximum number of instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
 | `sinkConfig` | The sink connector configurations in YAML format.|
 | `timeout` | The message timeout in milliseconds. |
 | `negativeAckRedeliveryDelayMs`| The number of redelivered messages due to negative acknowledgement. |

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -16,8 +16,8 @@ This table lists source configurations.
 | `tenant` | The tenant of a source connector. |
 | `namespace` | The Pulsar namespace of a source connector. |
 | `clusterName` | The Pulsar cluster of a source connector. |
-| `replicas`| The number of instances that you want to run for this source connector. If no value is set, the system will set `1` to it. |
-| `minReplicas`| The minimum number of instances that you want to run for this source connector. If no value is set, the system will set `1` to it. When HPA auto-scaling is enabled, the HPA controller scales up / down the Pods based on the values of the `minReplicas` and `maxReplicas` options. The number of the Pods should be greater than the value of the `minReplicas` while be smaller than the value of the `maxReplicas`.  |
+| `replicas`| The number of instances that you want to run for this source connector. If no value is set, the system will set it to `1`. |
+| `minReplicas`| The minimum number of instances that you want to run for this source connector. If no value is set, the system will set it to `1`. When HPA auto-scaling is enabled, the HPA controller scales the Pods up / down based on the values of the `minReplicas` and `maxReplicas` options. The number of the Pods should be greater than the value of the `minReplicas` and be smaller than the value of the `maxReplicas`.  |
 | `maxReplicas`| The maximum number of instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
 | `sourceConfig` | The source connector configurations in YAML format. |
 | `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -16,8 +16,9 @@ This table lists source configurations.
 | `tenant` | The tenant of a source connector. |
 | `namespace` | The Pulsar namespace of a source connector. |
 | `clusterName` | The Pulsar cluster of a source connector. |
-| `replicas`| The number of instances that you want to run this source connector. |
-| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `replicas`| The number of instances that you want to run for this source connector. If no value is set, the system will set `1` to it. |
+| `minReplicas`| The minimum number of instances that you want to run for this source connector. If no value is set, the system will set `1` to it. When HPA auto-scaling is enabled, the HPA controller scales up / down the Pods based on the values of the `minReplicas` and `maxReplicas` options. The number of the Pods should be greater than the value of the `minReplicas` while be smaller than the value of the `maxReplicas`.  |
+| `maxReplicas`| The maximum number of instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
 | `sourceConfig` | The source connector configurations in YAML format. |
 | `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
 | `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -17,8 +17,8 @@ This table lists Pulsar Function configurations.
 | `tenant` | The tenant of a Pulsar Function. |
 | `namespace` | The Pulsar namespace of a Pulsar Function. |
 | `clusterName` | The Pulsar cluster of a Pulsar Function. |
-| `replicas`| The number of instances that you want to run this Pulsar Function. If no value is set, the system will set `1` to it. |
-| `minReplicas`| The minimum number of instances that you want to run for this Pulsar function. If no value is set, the system will set `1` to it. When HPA auto-scaling is enabled, the HPA controller scales up / down the Pods based on the values of the `minReplicas` and `maxReplicas` options. The number of the Pods should be greater than the value of the `minReplicas` while be smaller than the value of the `maxReplicas`.  |
+| `replicas`| The number of instances that you want to run this Pulsar Function. If no value is set, the system will set it to `1`. |
+| `minReplicas`| The minimum number of instances that you want to run for this Pulsar function. If no value is set, the system will set it to `1`. When HPA auto-scaling is enabled, the HPA controller scales the Pods up / down based on the values of the `minReplicas` and `maxReplicas` options. The number of the Pods should be greater than the value of the `minReplicas` and be smaller than the value of the `maxReplicas`.  |
 | `maxReplicas`| The maximum number of instances that you want to run for this Pulsar function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
 | `timeout` | The message timeout in milliseconds. |
 | `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -17,8 +17,9 @@ This table lists Pulsar Function configurations.
 | `tenant` | The tenant of a Pulsar Function. |
 | `namespace` | The Pulsar namespace of a Pulsar Function. |
 | `clusterName` | The Pulsar cluster of a Pulsar Function. |
-| `replicas`| The number of instances that you want to run this Pulsar Function. By default, the `replicas` is set to `1`. |
-| `maxReplicas`| The maximum number of Pulsar instances that you want to run for this Pulsar Function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
+| `replicas`| The number of instances that you want to run this Pulsar Function. If no value is set, the system will set `1` to it. |
+| `minReplicas`| The minimum number of instances that you want to run for this Pulsar function. If no value is set, the system will set `1` to it. When HPA auto-scaling is enabled, the HPA controller scales up / down the Pods based on the values of the `minReplicas` and `maxReplicas` options. The number of the Pods should be greater than the value of the `minReplicas` while be smaller than the value of the `maxReplicas`.  |
+| `maxReplicas`| The maximum number of instances that you want to run for this Pulsar function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
 | `timeout` | The message timeout in milliseconds. |
 | `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
 | `funcConfig` | Pulsar Functions configurations in YAML format. |

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -32,11 +32,11 @@ For resources with HPA configured, the HPA controller monitors the resource's Po
 
 ### Supported auto-scaling metrics
 
-Function Mesh auto-scales the number of Pods based on the CPU usage, memory usage, custom metrics.
+Function Mesh auto-scales the number of Pods based on the CPU usage, memory usage, and custom metrics.
 
 > **Note**
 >
-> If you have configured autoscaling based on the CPU usage, memory usage, or both of them, you do not need to configure autoscaling based on custom metrics defined in Pulsar Functions or connectors and vice versa.
+> If you have configured autoscaling based on the CPU usage and/or memory usage, you do not need to configure autoscaling based on custom metrics defined in Pulsar Functions or connectors and vice versa.
 
 - CPU usage: auto-scale the number of Pods based on CPU utilization.
   
@@ -93,7 +93,7 @@ spec:
 
 #### Configure autoscaling with built-in metrics
 
-Function Mesh supports auto-scales the number of Pods based on [supported built-in metrics](#supported-auto-scaling-metrics).
+Function Mesh supports autoscaling the number of Pods based on [supported built-in metrics](#supported-auto-scaling-metrics).
 
   >**Note**
   >

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -4,23 +4,13 @@ category: scaling
 id: scaling
 ---
 
-Autoscaling monitors your Pods and automatically adjusts capacity to maintain steady, predictable performance at the lowest possible cost. With autoscaling, it is easy to set up Pods scaling for resources in minutes. The service provides a simple, powerful user interface that lets you build scaling plans for resources.
-
-This document describes how to scale Pods (Pulsar instances) which are used for running functions, sources, and sinks.
-
-## How it works
-
-With Kubernetes [Horizontal Pod Autoscaler (HPA)](https://kubernetes.io/docs/tasks/run-application/horizontal-Pod-autoscale/), Function Mesh supports automatically scaling the number of Pods (Pulsar instances) that are required to run for Pulsar functions, sources, and sinks.
-
-For resources with HPA configured, the HPA controller monitors the resource's Pods to determine if it needs to change the number of Pod replicas. In most cases, where the controller takes the mean of a per-pod metric value, it calculates whether adding or removing replicas would move the current value closer to the target value.
-
-![scaling](./assets/scaling.png)
+This document describes how to manually and automatically scale Pods (Pulsar instances) which are used for running functions, sources, and sinks.
 
 ## Manual scaling
 
 In CRDs, the `replicas` parameter is used to specify the number of Pods (Pulsar instances) that are required for running Pulsar functions, sources, or sinks. You can set the number of Pods based on the CPU threshold. When the target CPU threshold is reached, you can scale the Pods manually through either of the two ways:
 
-- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kunectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
+- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kubectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
 
     ```bash
     kubectl scale --replicas="" pod/POD_NAME
@@ -30,11 +20,27 @@ In CRDs, the `replicas` parameter is used to specify the number of Pods (Pulsar 
 
 ## Autoscaling
 
-Function Mesh auto-scales the number of Pods based on the CPU usage, memory usage, customized metrics. 
+Autoscaling monitors your Pods and automatically adjusts capacity to maintain steady, predictable performance at the lowest possible cost. With autoscaling, it is easy to set up Pods scaling for resources in minutes. The service provides a simple, powerful user interface that lets you build scaling plans for resources.
+
+### How it works
+
+With Kubernetes [Horizontal Pod Autoscaler (HPA)](https://kubernetes.io/docs/tasks/run-application/horizontal-Pod-autoscale/), Function Mesh supports automatically scaling the number of Pods (Pulsar instances) that are required to run Pulsar functions, sources, and sinks.
+
+For resources with HPA configured, the HPA controller monitors the resource's Pods to determine if it needs to change the number of Pod replicas. In most cases, where the controller takes the mean of a per-pod metric value, it calculates whether adding or removing replicas would move the current value closer to the target value.
+
+![scaling](./assets/scaling.png)
+
+### Supported auto-scaling metrics
+
+Function Mesh auto-scales the number of Pods based on the CPU usage, memory usage, custom metrics.
+
+> **Note**
+>
+> If you have configured autoscaling based on the CPU usage, memory usage, or both of them, you do not need to configure autoscaling based on custom metrics defined in Pulsar Functions or connectors and vice versa.
 
 - CPU usage: auto-scale the number of Pods based on CPU utilization.
   
-  This table lists built-in CPU-based autoscaling metrics. If these metrics do not meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
+  This table lists built-in CPU-based autoscaling metrics. If these metrics do not meet your requirements, you can auto-scale the number of Pods based on custom metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
   
   | Option | Description |
   | --- | --- |
@@ -44,7 +50,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
-  This table lists built-in memory-based autoscaling metrics. If these metrics do not meet your requirements, you can auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
+  This table lists built-in memory-based autoscaling metrics. If these metrics do not meet your requirements, you can auto-scale the number of Pods based on custom metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
   
   | Option | Description |
   | --- | --- |
@@ -52,95 +58,90 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is utilized. |
   | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is utilized. |
 
-- metrics: auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
-
-> **Note**
->
-> If you have configured autoscaling based on the CPU usage, memory usage, or both of them, you do not need to configure autoscaling based on customized metrics defined in Pulsar Functions or connectors and vice versa.
-
-By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is utilized.
-
-### Prerequisites
-
-Deploy the metrics server in the cluster. The Metrics server provides metrics through the Metrics API. The Horizontal Pod Autoscaler (HPA) uses this API to collect metrics. To learn how to deploy the metrics-server, see the [metrics-server documentation](https://github.com/kubernetes-sigs/metrics-server#deployment).
+- Custom metrics: auto-scale the number of Pods based on custom metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
 
 ### Examples
 
-These examples describe how to auto-scale the number of Pods running Pulsar Functions.
+This section provides some examples about autoscaling.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplica` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+#### Prerequisites
 
-  1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
+Deploy the metrics server in the cluster. The Metrics server provides metrics through the Metrics API. The Horizontal Pod Autoscaler (HPA) uses this API to collect metrics. To learn how to deploy the metrics-server, see the [metrics-server documentation](https://github.com/kubernetes-sigs/metrics-server#deployment).
 
-      ```yaml
-      apiVersion: cloud.streamnative.io/v1alpha1
-      kind: Function
-      metadata:
-        name: java-function-sample
-        namespace: default
-      spec:
-        className: org.apache.pulsar.functions.api.examples.ExclamationFunction
-        forwardSourceMessageProperty: true
-        maxPendingAsyncRequests: 1000
-        replicas: 1
-        maxReplicas: 8
-        logTopic: persistent://public/default/logging-function-logs
-        input:
-          topics:
-          - persistent://public/default/java-function-input-topic
-          typeClassName: java.lang.String
-        output:
-          topic: persistent://public/default/java-function-output-topic
-          typeClassName: java.lang.String
-        # Other function configs
-      ```
+#### Enable autoscaling
 
-  2. Apply the configurations.
+By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter.
 
-      ```bash
-      kubectl apply -f path/to/source-sample.yaml
-      ```
+By default, when autoscaling is enabled, the number of Pods is automatically scaled when 80% CPU is utilized.
 
-- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is utilized.
+This example shows how to enable autoscaling by setting the value of the `maxReplicas` to `8`.
 
-  1. Specify the CPU-based autoscaling metric under `pod.builtinAutoscaler` in the Pulsar Functions CRD.
+```yaml
+apiVersion: cloud.streamnative.io/v1alpha1
+kind: Function
+metadata:
+  name: java-function-sample
+  namespace: default
+spec:
+  className: org.apache.pulsar.functions.api.examples.ExclamationFunction
+  forwardSourceMessageProperty: true
+  maxPendingAsyncRequests: 1000
+  replicas: 1
+  maxReplicas: 8
+  # Other function configs
+```
 
-      ```yaml
-      apiVersion: cloud.streamnative.io/v1alpha1
-      kind: Function
-      metadata:
-        name: java-function-sample
-        namespace: default
-      spec:
-        className: org.apache.pulsar.functions.api.examples.ExclamationFunction
-        forwardSourceMessageProperty: true
-        maxPendingAsyncRequests: 1000
-        replicas: 1
-        maxReplicas: 4
-        logTopic: persistent://public/default/logging-function-logs
-        input:
-          topics:
-          - persistent://public/default/java-function-input-topic
-          typeClassName: java.lang.String
-        pod:
-          builtinAutoscaler:
-            - AverageUtilizationCPUPercent20
-        # Other function configs
-      ```
+#### Configure autoscaling with built-in metrics
 
-  2. Apply the configurations.
-
-      ```bash
-      kubectl apply -f path/to/source-sample.yaml
-      ```
+Function Mesh supports auto-scales the number of Pods based on [supported built-in metrics](#supported-auto-scaling-metrics).
 
   >**Note**
   >
-  > If you specify multiple metrics for the HPA to scale on, the HPA controller evaluates each metric, and proposes a new scale based on that metric. The largest of the proposed scales will be used as the new scale.
+  > If you specify multiple metrics for the HPA to scale up, the HPA controller evaluates each metric, and proposes a new scale based on that metric. The largest of the proposed scales will be used as the new scale.
 
-- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is utilized.
+This example shows how to auto-scale the number of Pods to `8` when 20% CPU is utilized.
 
-  1. Specify the customized autoscaling metric under `pod.autoScalingMetrics` in the Pulsar Functions CRD.
+1. Specify the CPU-based autoscaling metric under `pod.builtinAutoscaler` in the Pulsar Functions CRD.
+
+    ```yaml
+    apiVersion: cloud.streamnative.io/v1alpha1
+    kind: Function
+    metadata:
+      name: java-function-sample
+      namespace: default
+    spec:
+      className: org.apache.pulsar.functions.api.examples.ExclamationFunction
+      forwardSourceMessageProperty: true
+      maxPendingAsyncRequests: 1000
+      replicas: 1
+      maxReplicas: 4                    --- [1]
+      logTopic: persistent://public/default/logging-function-logs                    
+      input:                   
+        topics:                    
+        - persistent://public/default/java-function-input-topic                    
+        typeClassName: java.lang.String                    
+      pod:                    
+        builtinAutoscaler:               --- [2]
+          - AverageUtilizationCPUPercent20
+      # Other function configs
+    ```
+
+    - [1] `maxReplicas`: enables autoscaling when the value is greater than that of the `replicas`.
+    - [2] `builtinAutoscaler`: configures the built-in autoscaling metrics.
+
+2. Apply the configurations.
+
+    ```bash
+    kubectl apply -f path/to/function-sample.yaml
+    ```
+
+#### Configure autoscaling with custom metrics
+
+Function Mesh supports automatically scaling up the number of Pods based on a custom autoscaling metric. 
+
+- This example shows how to auto-scale the number of Pods if 45% CPU is utilized.
+
+  1. Specify the custom autoscaling metric under `pod.autoScalingMetrics` in the Pulsar Functions CRD.
 
       ```yaml
       apiVersion: cloud.streamnative.io/v1alpha1
@@ -153,21 +154,74 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
         forwardSourceMessageProperty: true
         maxPendingAsyncRequests: 1000
         replicas: 1
-        maxReplicas: 4
-        logTopic: persistent://public/default/logging-function-logs
-        pod:
-          autoScalingMetrics:
-          - type: Resource
-            resource:
-              name: cpu
-              target:
-                type: Utilization
-                averageUtilization: 45
+        maxReplicas: 4                         --- [1]
+        logTopic: persistent://public/default/logging-function-logs            
+        pod:            
+          autoScalingMetrics:                  --- [2]
+          - type: Resource           
+            resource:            
+              name: cpu                        --- [3]
+              target:             
+                type: Utilization              
+                averageUtilization: 45         --- [4]
         # Other function configs
       ```
+
+      - [1] `maxReplicas`: enables autoscaling when the value is greater than that of the `replicas`.
+      - [2] `autoScalingMetrics`: represents the custom autoscaling metrics.
+      - [3] `name`: defines the name of resources to be used. It can be set to the value `cpu` or `memory`.
+      - [4] `averageUtilization`: defines the percentage of the resource usage.
 
   2. Apply the configurations.
 
       ```bash
-      kubectl apply -f path/to/source-sample.yaml
+      kubectl apply -f path/to/function-sample.yaml
+      ```
+
+- If a large number of resources are utilized suddenly, you can use the `autoScalingBehavior.scaleUp.stabilizationWindowSeconds` option to adjust the value of the stabilization window to tune performance.
+
+  1. Specify the value of the stabilization window in the Pulsar Functions CRD.
+
+      ```yaml
+      apiVersion: cloud.streamnative.io/v1alpha1
+      kind: Function
+      metadata:
+        name: java-function-sample
+        namespace: default
+      spec:
+        minReplicas: 1
+        maxReplicas: 10
+        pod:
+          autoScalingMetrics:
+            - type: Resource
+              resource:
+                name: cpu
+                target:
+                  type: Utilization
+                  averageUtilization: 80
+          autoScalingBehavior:                     
+            scaleUp:                               --- [1]
+              stabilizationWindowSeconds: 120      --- [2]
+              policies:                            --- [3]
+              - type: Percent                      --- [4]
+                value: 100                         --- [5]
+                periodSeconds: 15                  --- [6]
+              - type: Pods                         
+                value: 4                           
+                periodSeconds: 15                  
+              selectPolicy: Max                    --- [7]
+      ```
+
+     - [1] `scaleUp`: specifies the rules which are used to control scaling behavior while scaling up.
+     - [2] `stabilizationWindowSeconds`: indicates the amount of time the HPA controller should consider previous recommendations to prevent flapping of the number of replicas.
+     - [3] `policies`: a list of policies which regulate the amount of scaling. Each item has the following fields:
+       - [4] `type`: can be set to the value `Pods` or `Percent`, which indicates the allowed changes in terms of absolute number of pods or percentage of current replicas.
+       - [5] `periodSeconds`: represents the amount of time in seconds for which the rule should hold true.
+       - [6] `value`: represents the value for the policy.
+     - [7] `selectPolicy`: can be `Min`, `Max` or `Disabled` and specifies which value from the policies should be selected. By default, it is set to `Max` value.
+
+  2. Apply the configurations.
+
+      ```bash
+      kubectl apply -f path/to/function-sample.yaml
       ```

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -4,7 +4,7 @@ category: scaling
 id: scaling
 ---
 
-This document describes how to manually and automatically scale Pods (Pulsar instances) which are used for running functions, sources, and sinks.
+This document describes how to manually and automatically scale Pods (Pulsar instances) that are used for running functions, sources, and sinks.
 
 ## Manual scaling
 
@@ -44,9 +44,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is utilized.|
-  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is utilized.|
-  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is utilized. |
+  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is used.|
+  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is used.|
+  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is used. |
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
@@ -54,9 +54,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is utilized. |
-  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is utilized. |
-  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is utilized. |
+  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is used. |
+  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is used. |
+  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is used. |
 
 - Custom metrics: auto-scale the number of Pods based on custom metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
 
@@ -72,7 +72,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter.
 
-By default, when autoscaling is enabled, the number of Pods is automatically scaled when 80% CPU is utilized.
+By default, when autoscaling is enabled, the number of Pods is automatically scaled when 80% CPU is used.
 
 This example shows how to enable autoscaling by setting the value of the `maxReplicas` to `8`.
 
@@ -99,7 +99,7 @@ Function Mesh supports auto-scales the number of Pods based on [supported built-
   >
   > If you specify multiple metrics for the HPA to scale up, the HPA controller evaluates each metric, and proposes a new scale based on that metric. The largest of the proposed scales will be used as the new scale.
 
-This example shows how to auto-scale the number of Pods to `8` when 20% CPU is utilized.
+This example shows how to auto-scale the number of Pods to `8` when 20% CPU is used.
 
 1. Specify the CPU-based autoscaling metric under `pod.builtinAutoscaler` in the Pulsar Functions CRD.
 
@@ -139,7 +139,7 @@ This example shows how to auto-scale the number of Pods to `8` when 20% CPU is u
 
 Function Mesh supports automatically scaling up the number of Pods based on a custom autoscaling metric. 
 
-- This example shows how to auto-scale the number of Pods if 45% CPU is utilized.
+- This example shows how to auto-scale the number of Pods if 45% CPU is used.
 
   1. Specify the custom autoscaling metric under `pod.autoScalingMetrics` in the Pulsar Functions CRD.
 
@@ -178,7 +178,7 @@ Function Mesh supports automatically scaling up the number of Pods based on a cu
       kubectl apply -f path/to/function-sample.yaml
       ```
 
-- If a large number of resources are utilized suddenly, you can use the `autoScalingBehavior.scaleUp.stabilizationWindowSeconds` option to adjust the value of the stabilization window to tune performance.
+- If a large number of resources are used suddenly, you can use the `autoScalingBehavior.scaleUp.stabilizationWindowSeconds` option to adjust the value of the stabilization window to tune performance.
 
   1. Specify the value of the stabilization window in the Pulsar Functions CRD.
 
@@ -212,11 +212,11 @@ Function Mesh supports automatically scaling up the number of Pods based on a cu
               selectPolicy: Max                    --- [7]
       ```
 
-     - [1] `scaleUp`: specifies the rules which are used to control scaling behavior while scaling up.
+     - [1] `scaleUp`: specifies the rules that are used to control scaling behavior while scaling up.
      - [2] `stabilizationWindowSeconds`: indicates the amount of time the HPA controller should consider previous recommendations to prevent flapping of the number of replicas.
-     - [3] `policies`: a list of policies which regulate the amount of scaling. Each item has the following fields:
+     - [3] `policies`: a list of policies that regulate the amount of scaling. Each item has the following fields:
        - [4] `type`: can be set to the value `Pods` or `Percent`, which indicates the allowed changes in terms of absolute number of pods or percentage of current replicas.
-       - [5] `periodSeconds`: represents the amount of time in seconds for which the rule should hold true.
+       - [5] `periodSeconds`: represents the amount of time in seconds that the rule should hold true for.
        - [6] `value`: represents the value for the policy.
      - [7] `selectPolicy`: can be `Min`, `Max` or `Disabled` and specifies which value from the policies should be selected. By default, it is set to `Max` value.
 

--- a/versioned_docs/version-0.1.10/scaling.md
+++ b/versioned_docs/version-0.1.10/scaling.md
@@ -38,9 +38,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is utilized.|
-  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is utilized.|
-  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is utilized. |
+  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is used.|
+  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is used.|
+  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is used. |
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
@@ -48,9 +48,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is utilized. |
-  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is utilized. |
-  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is utilized. |
+  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is used. |
+  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is used. |
+  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is used. |
 
 - metrics: auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
 
@@ -58,7 +58,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 >
 > If you have configured autoscaling based on the CPU usage, memory usage, or both of them, you do not need to configure autoscaling based on customized metrics defined in Pulsar Functions or connectors and vice versa.
 
-By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is utilized.
+By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is used.
 
 ### Prerequisites
 
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is used.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 
@@ -101,7 +101,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
       kubectl apply -f path/to/source-sample.yaml
       ```
 
-- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is used.
 
   1. Specify the CPU-based autoscaling metric under `pod.builtinAutoscaler` in the Pulsar Functions CRD.
 
@@ -138,7 +138,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
   >
   > If you specify multiple metrics for the HPA to scale on, the HPA controller evaluates each metric, and proposes a new scale based on that metric. The largest of the proposed scales will be used as the new scale.
 
-- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is used.
 
   1. Specify the customized autoscaling metric under `pod.autoScalingMetrics` in the Pulsar Functions CRD.
 

--- a/versioned_docs/version-0.1.10/scaling.md
+++ b/versioned_docs/version-0.1.10/scaling.md
@@ -20,7 +20,7 @@ For resources with HPA configured, the HPA controller monitors the resource's Po
 
 In CRDs, the `replicas` parameter is used to specify the number of Pods (Pulsar instances) that are required for running Pulsar functions, sources, or sinks. You can set the number of Pods based on the CPU threshold. When the target CPU threshold is reached, you can scale the Pods manually through either of the two ways:
 
-- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kunectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
+- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kubectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
 
     ```bash
     kubectl scale --replicas="" pod/POD_NAME
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplica` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 

--- a/versioned_docs/version-0.1.11/scaling.md
+++ b/versioned_docs/version-0.1.11/scaling.md
@@ -38,9 +38,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is utilized.|
-  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is utilized.|
-  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is utilized. |
+  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is used.|
+  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is used.|
+  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is used. |
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
@@ -48,9 +48,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is utilized. |
-  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is utilized. |
-  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is utilized. |
+  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is used. |
+  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is used. |
+  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is used. |
 
 - metrics: auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
 
@@ -58,7 +58,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 >
 > If you have configured autoscaling based on the CPU usage, memory usage, or both of them, you do not need to configure autoscaling based on customized metrics defined in Pulsar Functions or connectors and vice versa.
 
-By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is utilized.
+By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is used.
 
 ### Prerequisites
 
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is used.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 
@@ -101,7 +101,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
       kubectl apply -f path/to/source-sample.yaml
       ```
 
-- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is used.
 
   1. Specify the CPU-based autoscaling metric under `pod.builtinAutoscaler` in the Pulsar Functions CRD.
 
@@ -138,7 +138,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
   >
   > If you specify multiple metrics for the HPA to scale on, the HPA controller evaluates each metric, and proposes a new scale based on that metric. The largest of the proposed scales will be used as the new scale.
 
-- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is used.
 
   1. Specify the customized autoscaling metric under `pod.autoScalingMetrics` in the Pulsar Functions CRD.
 

--- a/versioned_docs/version-0.1.11/scaling.md
+++ b/versioned_docs/version-0.1.11/scaling.md
@@ -20,7 +20,7 @@ For resources with HPA configured, the HPA controller monitors the resource's Po
 
 In CRDs, the `replicas` parameter is used to specify the number of Pods (Pulsar instances) that are required for running Pulsar functions, sources, or sinks. You can set the number of Pods based on the CPU threshold. When the target CPU threshold is reached, you can scale the Pods manually through either of the two ways:
 
-- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kunectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
+- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kubectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
 
     ```bash
     kubectl scale --replicas="" pod/POD_NAME
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplica` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 

--- a/versioned_docs/version-0.1.4/scaling.md
+++ b/versioned_docs/version-0.1.4/scaling.md
@@ -20,7 +20,7 @@ For resources with HPA configured, the HPA controller monitors the resource's Po
 
 In CRDs, the `replicas` parameter is used to specify the number of Pods (Pulsar instances) that are required for running Pulsar functions, sources, or sinks. You can set the number of Pods based on the CPU threshold. When the target CPU threshold is reached, you can scale the Pods manually through either of the two ways:
 
-- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kunectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
+- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kubectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
 
     ```bash
     kubectl scale --replicas="" pod/POD_NAME

--- a/versioned_docs/version-0.1.5/scaling.md
+++ b/versioned_docs/version-0.1.5/scaling.md
@@ -20,7 +20,7 @@ For resources with HPA configured, the HPA controller monitors the resource's Po
 
 In CRDs, the `replicas` parameter is used to specify the number of Pods (Pulsar instances) that are required for running Pulsar functions, sources, or sinks. You can set the number of Pods based on the CPU threshold. When the target CPU threshold is reached, you can scale the Pods manually through either of the two ways:
 
-- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kunectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
+- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kubectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
 
     ```bash
     kubectl scale --replicas="" pod/POD_NAME

--- a/versioned_docs/version-0.1.6/scaling.md
+++ b/versioned_docs/version-0.1.6/scaling.md
@@ -20,7 +20,7 @@ For resources with HPA configured, the HPA controller monitors the resource's Po
 
 In CRDs, the `replicas` parameter is used to specify the number of Pods (Pulsar instances) that are required for running Pulsar functions, sources, or sinks. You can set the number of Pods based on the CPU threshold. When the target CPU threshold is reached, you can scale the Pods manually through either of the two ways:
 
-- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kunectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
+- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kubectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
 
     ```bash
     kubectl scale --replicas="" pod/POD_NAME

--- a/versioned_docs/version-0.1.7/scaling.md
+++ b/versioned_docs/version-0.1.7/scaling.md
@@ -38,9 +38,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is utilized.|
-  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is utilized.|
-  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is utilized. |
+  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is used.|
+  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is used.|
+  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is used. |
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
@@ -48,9 +48,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is utilized. |
-  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is utilized. |
-  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is utilized. |
+  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is used. |
+  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is used. |
+  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is used. |
 
 - metrics: auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
 
@@ -58,7 +58,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 >
 > If you have configured autoscaling based on the CPU usage, memory usage, or both of them, you do not need to configure autoscaling based on customized metrics defined in Pulsar Functions or connectors and vice versa.
 
-By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is utilized.
+By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is used.
 
 ### Prerequisites
 
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is used.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 
@@ -101,7 +101,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
       kubectl apply -f path/to/source-sample.yaml
       ```
 
-- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is used.
 
   1. Specify the CPU-based autoscaling metric under `pod.builtinAutoscaler` in the Pulsar Functions CRD.
 
@@ -138,7 +138,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
   >
   > If you specify multiple metrics for the HPA to scale on, the HPA controller evaluates each metric, and proposes a new scale based on that metric. The largest of the proposed scales will be used as the new scale.
 
-- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is used.
 
   1. Specify the customized autoscaling metric under `pod.autoScalingMetrics` in the Pulsar Functions CRD.
 

--- a/versioned_docs/version-0.1.7/scaling.md
+++ b/versioned_docs/version-0.1.7/scaling.md
@@ -20,7 +20,7 @@ For resources with HPA configured, the HPA controller monitors the resource's Po
 
 In CRDs, the `replicas` parameter is used to specify the number of Pods (Pulsar instances) that are required for running Pulsar functions, sources, or sinks. You can set the number of Pods based on the CPU threshold. When the target CPU threshold is reached, you can scale the Pods manually through either of the two ways:
 
-- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kunectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
+- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kubectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
 
     ```bash
     kubectl scale --replicas="" pod/POD_NAME
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplica` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 

--- a/versioned_docs/version-0.1.8/scaling.md
+++ b/versioned_docs/version-0.1.8/scaling.md
@@ -38,9 +38,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is utilized.|
-  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is utilized.|
-  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is utilized. |
+  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is used.|
+  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is used.|
+  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is used. |
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
@@ -48,9 +48,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is utilized. |
-  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is utilized. |
-  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is utilized. |
+  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is used. |
+  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is used. |
+  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is used. |
 
 - metrics: auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
 
@@ -58,7 +58,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 >
 > If you have configured autoscaling based on the CPU usage, memory usage, or both of them, you do not need to configure autoscaling based on customized metrics defined in Pulsar Functions or connectors and vice versa.
 
-By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is utilized.
+By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is used.
 
 ### Prerequisites
 
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is used.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 
@@ -101,7 +101,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
       kubectl apply -f path/to/source-sample.yaml
       ```
 
-- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is used.
 
   1. Specify the CPU-based autoscaling metric under `pod.builtinAutoscaler` in the Pulsar Functions CRD.
 
@@ -138,7 +138,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
   >
   > If you specify multiple metrics for the HPA to scale on, the HPA controller evaluates each metric, and proposes a new scale based on that metric. The largest of the proposed scales will be used as the new scale.
 
-- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is used.
 
   1. Specify the customized autoscaling metric under `pod.autoScalingMetrics` in the Pulsar Functions CRD.
 

--- a/versioned_docs/version-0.1.8/scaling.md
+++ b/versioned_docs/version-0.1.8/scaling.md
@@ -20,7 +20,7 @@ For resources with HPA configured, the HPA controller monitors the resource's Po
 
 In CRDs, the `replicas` parameter is used to specify the number of Pods (Pulsar instances) that are required for running Pulsar functions, sources, or sinks. You can set the number of Pods based on the CPU threshold. When the target CPU threshold is reached, you can scale the Pods manually through either of the two ways:
 
-- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kunectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
+- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kubectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
 
     ```bash
     kubectl scale --replicas="" pod/POD_NAME
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplica` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 

--- a/versioned_docs/version-0.1.9/scaling.md
+++ b/versioned_docs/version-0.1.9/scaling.md
@@ -38,9 +38,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is utilized.|
-  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is utilized.|
-  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is utilized. |
+  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is used.|
+  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is used.|
+  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is used. |
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
@@ -48,9 +48,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is utilized. |
-  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is utilized. |
-  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is utilized. |
+  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is used. |
+  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is used. |
+  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is used. |
 
 - metrics: auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
 
@@ -58,7 +58,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 >
 > If you have configured autoscaling based on the CPU usage, memory usage, or both of them, you do not need to configure autoscaling based on customized metrics defined in Pulsar Functions or connectors and vice versa.
 
-By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is utilized.
+By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is used.
 
 ### Prerequisites
 
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is used.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 
@@ -101,7 +101,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
       kubectl apply -f path/to/source-sample.yaml
       ```
 
-- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is used.
 
   1. Specify the CPU-based autoscaling metric under `pod.builtinAutoscaler` in the Pulsar Functions CRD.
 
@@ -138,7 +138,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
   >
   > If you specify multiple metrics for the HPA to scale on, the HPA controller evaluates each metric, and proposes a new scale based on that metric. The largest of the proposed scales will be used as the new scale.
 
-- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is used.
 
   1. Specify the customized autoscaling metric under `pod.autoScalingMetrics` in the Pulsar Functions CRD.
 

--- a/versioned_docs/version-0.1.9/scaling.md
+++ b/versioned_docs/version-0.1.9/scaling.md
@@ -20,7 +20,7 @@ For resources with HPA configured, the HPA controller monitors the resource's Po
 
 In CRDs, the `replicas` parameter is used to specify the number of Pods (Pulsar instances) that are required for running Pulsar functions, sources, or sinks. You can set the number of Pods based on the CPU threshold. When the target CPU threshold is reached, you can scale the Pods manually through either of the two ways:
 
-- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kunectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
+- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kubectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
 
     ```bash
     kubectl scale --replicas="" pod/POD_NAME
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplica` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 

--- a/versioned_docs/version-0.2.0/scaling.md
+++ b/versioned_docs/version-0.2.0/scaling.md
@@ -38,9 +38,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is utilized.|
-  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is utilized.|
-  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is utilized. |
+  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is used.|
+  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is used.|
+  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is used. |
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
@@ -48,9 +48,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is utilized. |
-  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is utilized. |
-  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is utilized. |
+  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is used. |
+  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is used. |
+  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is used. |
 
 - metrics: auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
 
@@ -58,7 +58,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 >
 > If you have configured autoscaling based on the CPU usage, memory usage, or both of them, you do not need to configure autoscaling based on customized metrics defined in Pulsar Functions or connectors and vice versa.
 
-By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is utilized.
+By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is used.
 
 ### Prerequisites
 
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is used.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 
@@ -101,7 +101,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
       kubectl apply -f path/to/source-sample.yaml
       ```
 
-- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is used.
 
   1. Specify the CPU-based autoscaling metric under `pod.builtinAutoscaler` in the Pulsar Functions CRD.
 
@@ -138,7 +138,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
   >
   > If you specify multiple metrics for the HPA to scale on, the HPA controller evaluates each metric, and proposes a new scale based on that metric. The largest of the proposed scales will be used as the new scale.
 
-- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is used.
 
   1. Specify the customized autoscaling metric under `pod.autoScalingMetrics` in the Pulsar Functions CRD.
 

--- a/versioned_docs/version-0.2.0/scaling.md
+++ b/versioned_docs/version-0.2.0/scaling.md
@@ -20,7 +20,7 @@ For resources with HPA configured, the HPA controller monitors the resource's Po
 
 In CRDs, the `replicas` parameter is used to specify the number of Pods (Pulsar instances) that are required for running Pulsar functions, sources, or sinks. You can set the number of Pods based on the CPU threshold. When the target CPU threshold is reached, you can scale the Pods manually through either of the two ways:
 
-- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kunectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
+- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kubectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
 
     ```bash
     kubectl scale --replicas="" pod/POD_NAME
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplica` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 

--- a/versioned_docs/version-0.3.0/scaling.md
+++ b/versioned_docs/version-0.3.0/scaling.md
@@ -38,9 +38,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is utilized.|
-  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is utilized.|
-  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is utilized. |
+  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is used.|
+  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is used.|
+  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is used. |
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
@@ -48,9 +48,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is utilized. |
-  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is utilized. |
-  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is utilized. |
+  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is used. |
+  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is used. |
+  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is used. |
 
 - metrics: auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
 
@@ -58,7 +58,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 >
 > If you have configured autoscaling based on the CPU usage, memory usage, or both of them, you do not need to configure autoscaling based on customized metrics defined in Pulsar Functions or connectors and vice versa.
 
-By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is utilized.
+By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is used.
 
 ### Prerequisites
 
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is used.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 
@@ -101,7 +101,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
       kubectl apply -f path/to/source-sample.yaml
       ```
 
-- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is used.
 
   1. Specify the CPU-based autoscaling metric under `pod.builtinAutoscaler` in the Pulsar Functions CRD.
 
@@ -138,7 +138,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
   >
   > If you specify multiple metrics for the HPA to scale on, the HPA controller evaluates each metric, and proposes a new scale based on that metric. The largest of the proposed scales will be used as the new scale.
 
-- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is used.
 
   1. Specify the customized autoscaling metric under `pod.autoScalingMetrics` in the Pulsar Functions CRD.
 

--- a/versioned_docs/version-0.3.0/scaling.md
+++ b/versioned_docs/version-0.3.0/scaling.md
@@ -20,7 +20,7 @@ For resources with HPA configured, the HPA controller monitors the resource's Po
 
 In CRDs, the `replicas` parameter is used to specify the number of Pods (Pulsar instances) that are required for running Pulsar functions, sources, or sinks. You can set the number of Pods based on the CPU threshold. When the target CPU threshold is reached, you can scale the Pods manually through either of the two ways:
 
-- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kunectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
+- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kubectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
 
     ```bash
     kubectl scale --replicas="" pod/POD_NAME
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplica` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 

--- a/versioned_docs/version-0.4.0/scaling.md
+++ b/versioned_docs/version-0.4.0/scaling.md
@@ -38,9 +38,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is utilized.|
-  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is utilized.|
-  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is utilized. |
+  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is used.|
+  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is used.|
+  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is used. |
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
@@ -48,9 +48,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is utilized. |
-  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is utilized. |
-  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is utilized. |
+  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is used. |
+  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is used. |
+  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is used. |
 
 - metrics: auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
 
@@ -58,7 +58,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 >
 > If you have configured autoscaling based on the CPU usage, memory usage, or both of them, you do not need to configure autoscaling based on customized metrics defined in Pulsar Functions or connectors and vice versa.
 
-By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is utilized.
+By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is used.
 
 ### Prerequisites
 
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is used.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 
@@ -101,7 +101,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
       kubectl apply -f path/to/source-sample.yaml
       ```
 
-- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is used.
 
   1. Specify the CPU-based autoscaling metric under `pod.builtinAutoscaler` in the Pulsar Functions CRD.
 
@@ -138,7 +138,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
   >
   > If you specify multiple metrics for the HPA to scale on, the HPA controller evaluates each metric, and proposes a new scale based on that metric. The largest of the proposed scales will be used as the new scale.
 
-- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is used.
 
   1. Specify the customized autoscaling metric under `pod.autoScalingMetrics` in the Pulsar Functions CRD.
 

--- a/versioned_docs/version-0.4.0/scaling.md
+++ b/versioned_docs/version-0.4.0/scaling.md
@@ -20,7 +20,7 @@ For resources with HPA configured, the HPA controller monitors the resource's Po
 
 In CRDs, the `replicas` parameter is used to specify the number of Pods (Pulsar instances) that are required for running Pulsar functions, sources, or sinks. You can set the number of Pods based on the CPU threshold. When the target CPU threshold is reached, you can scale the Pods manually through either of the two ways:
 
-- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kunectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
+- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kubectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
 
     ```bash
     kubectl scale --replicas="" pod/POD_NAME
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplica` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 

--- a/versioned_docs/version-0.5.0/scaling.md
+++ b/versioned_docs/version-0.5.0/scaling.md
@@ -38,9 +38,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is utilized.|
-  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is utilized.|
-  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is utilized. |
+  | AverageUtilizationCPUPercent80 | Auto-scale the number of Pods if 80% CPU is used.|
+  | AverageUtilizationCPUPercent50 | Auto-scale the number of Pods if 50% CPU is used.|
+  | AverageUtilizationCPUPercent20 | Auto-scale the number of Pods if 20% CPU is used. |
 
 - Memory usage: auto-scale the number of Pods based on memory utilization.
   
@@ -48,9 +48,9 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
   
   | Option | Description |
   | --- | --- |
-  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is utilized. |
-  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is utilized. |
-  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is utilized. |
+  | AverageUtilizationMemoryPercent80 | Auto-scale the number of Pods if 80% memory is used. |
+  | AverageUtilizationMemoryPercent50 | Auto-scale the number of Pods if 50% memory is used. |
+  | AverageUtilizationMemoryPercent20 | Auto-scale the number of Pods if 20% memory is used. |
 
 - metrics: auto-scale the number of Pods based on customized metrics defined in Pulsar Functions or connectors. For details, see [MetricSpec v2beta2 autoscaling](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#metricspec-v2beta2-autoscaling).
 
@@ -58,7 +58,7 @@ Function Mesh auto-scales the number of Pods based on the CPU usage, memory usag
 >
 > If you have configured autoscaling based on the CPU usage, memory usage, or both of them, you do not need to configure autoscaling based on customized metrics defined in Pulsar Functions or connectors and vice versa.
 
-By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is utilized.
+By default, autoscaling is disabled (the value of the `maxReplicas` parameter is set to `0`). To enable autoscaling, you can specify the `maxReplicas` parameter and set a value for it in the CRD. This value should be greater than the value of the `replicas` parameter. Then, the number of Pods is automatically scaled when 80% CPU is used.
 
 ### Prerequisites
 
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is used.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 
@@ -101,7 +101,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
       kubectl apply -f path/to/source-sample.yaml
       ```
 
-- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a built-in autoscaling metric. This example auto-scales the number of Pods if 20% CPU is used.
 
   1. Specify the CPU-based autoscaling metric under `pod.builtinAutoscaler` in the Pulsar Functions CRD.
 
@@ -138,7 +138,7 @@ These examples describe how to auto-scale the number of Pods running Pulsar Func
   >
   > If you specify multiple metrics for the HPA to scale on, the HPA controller evaluates each metric, and proposes a new scale based on that metric. The largest of the proposed scales will be used as the new scale.
 
-- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods based on a customized autoscaling metric. This example auto-scales the number of Pods if 45% CPU is used.
 
   1. Specify the customized autoscaling metric under `pod.autoScalingMetrics` in the Pulsar Functions CRD.
 

--- a/versioned_docs/version-0.5.0/scaling.md
+++ b/versioned_docs/version-0.5.0/scaling.md
@@ -20,7 +20,7 @@ For resources with HPA configured, the HPA controller monitors the resource's Po
 
 In CRDs, the `replicas` parameter is used to specify the number of Pods (Pulsar instances) that are required for running Pulsar functions, sources, or sinks. You can set the number of Pods based on the CPU threshold. When the target CPU threshold is reached, you can scale the Pods manually through either of the two ways:
 
-- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kunectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
+- Use the `kubectl scale --replicas` command. The CLI command does not change the `replicas` configuration in the CRD. If you use the `kubectl apply -f` command to re-submit the CRD file, the CLI configuration may be overwritten.
 
     ```bash
     kubectl scale --replicas="" pod/POD_NAME
@@ -68,7 +68,7 @@ Deploy the metrics server in the cluster. The Metrics server provides metrics th
 
 These examples describe how to auto-scale the number of Pods running Pulsar Functions.
 
-- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplica` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
+- Function Mesh supports automatically scaling up the number of Pods by updating the `maxReplicas` parameter. In this case, the number of Pods is updated to `8` when 80% CPU is utilized.
 
   1. Specify the `maxReplicas` to `8` in the Pulsar Functions CRD. The `maxReplicas` refers to the maximum number of Pods that are required for running the Pulsar Functions.
 


### PR DESCRIPTION
### Motivation

Function Mesh v0.6.0 enhanced HAP auto-scaling ([code PR #450]( https://github.com/streamnative/function-mesh/pull/450)), therefore add docs accordingly.

### Modification

- Function Mesh v0.6.0
  - Function/Source/Sink CRD configurations
    - Add an item "minReplicas"
  - Scaling:
    - Restructure the doc and add more examples
- Legacy releases
  - Update typos
  - change `kunectl` to `kubectl`
  - change `maxReplica` to `maxReplicas`