### PR TITLE
[FMv0.6]--Update docs for OAuth2 configs

### DIFF
--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -166,7 +166,7 @@ Function Mesh provides the `tlsConfig`, `tlsSecret`, `authSecret`, `authConfig` 
       </tr>
       <tr>
         <td><code>issuerUrl</code></td>
-        <td>The URL of the authentication provider which allows a Pulsar client to obtain an access token.</td>
+        <td>The URL of the authentication provider that allows a Pulsar client to obtain an access token.</td>
       </tr>
       <tr>
         <td><code>scope</code></td>

--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -115,7 +115,7 @@ Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("u
 
 ## Authentication
 
-Function Mesh provides the `tlsConfig`, `tlsSecret`, and `authSecret` fields for Function, Source, and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsConfig`, `tlsSecret`, `authSecret`, `authConfig` fields for Function, Source, and Sink in the CRD definition. You can configure TLS encryption, TLS authentication, and OAuth2 authentication using the following configurations.
 
 > **Note**
 > 
@@ -145,6 +145,42 @@ Function Mesh provides the `tlsConfig`, `tlsSecret`, and `authSecret` fields for
     | --- | --- |
     | `clientAuthenticationPlugin` | The client authentication plugin. |
     | `clientAuthenticationParameters` | The client authentication parameters. |
+
+- Authentication configurations
+
+    > **Note**
+    >
+    > Currently, only [OAuth2 authentication](https://oauth.net/) configurations are supported. For other authentication methods, you can configure them using the Authentication Secret.
+
+    <table>
+      <tr>
+        <th>Field</th>
+        <th>Description</th>
+      </tr>
+      <tr>
+        <td colspan="2"><b>OAuth2 authentication</b></td>
+      </tr>
+      <tr>
+        <td><code>audience</code></td>
+        <td>The OAuth2 "resource server" identifier for the Pulsar cluster.</td>
+      </tr>
+      <tr>
+        <td><code>issuerUrl</code></td>
+        <td>The URL of the authentication provider which allows a Pulsar client to obtain an access token.</td>
+      </tr>
+      <tr>
+        <td><code>scope</code></td>
+        <td>The scope of an access request. For more information, see [access token scope](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).</td>
+      </tr>
+      <tr>
+        <td><code>keySecretName</code></td>
+        <td>The name of the Kubernetes secret.</td>
+      </tr>
+      <tr>
+        <td><code>keySecretKey</code></td>
+        <td>The key of the Kubernetes secret, which contains the content of the OAuth2 private key.</td>
+      </tr>
+    </table>
 
 ## Packages
 

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -108,7 +108,7 @@ Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("u
 
 ## Authentication
 
-Function Mesh provides the `tlsConfig`, `tlsSecret`, and `authSecret` fields for Function, Source, and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsConfig`, `tlsSecret`, `authSecret`, `authConfig` fields for Function, Source, and Sink in the CRD definition. You can configure TLS encryption, TLS authentication, and OAuth2 authentication using the following configurations.
 
 > **Note**
 > 
@@ -138,6 +138,42 @@ Function Mesh provides the `tlsConfig`, `tlsSecret`, and `authSecret` fields for
     | --- | --- |
     | `clientAuthenticationPlugin` | The client authentication plugin. |
     | `clientAuthenticationParameters` | The client authentication parameters. |
+
+- Authentication configurations
+
+    > **Note**
+    >
+    > Currently, only [OAuth2 authentication](https://oauth.net/) configurations are supported. For other authentication methods, you can configure them using the Authentication Secret.
+
+    <table>
+      <tr>
+        <th>Field</th>
+        <th>Description</th>
+      </tr>
+      <tr>
+        <td colspan="2"><b>OAuth2 authentication</b></td>
+      </tr>
+      <tr>
+        <td><code>audience</code></td>
+        <td>The OAuth2 "resource server" identifier for the Pulsar cluster.</td>
+      </tr>
+      <tr>
+        <td><code>issuerUrl</code></td>
+        <td>The URL of the authentication provider which allows a Pulsar client to obtain an access token.</td>
+      </tr>
+      <tr>
+        <td><code>scope</code></td>
+        <td>The scope of an access request. For more information, see [access token scope](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).</td>
+      </tr>
+      <tr>
+        <td><code>keySecretName</code></td>
+        <td>The name of the Kubernetes secret.</td>
+      </tr>
+      <tr>
+        <td><code>keySecretKey</code></td>
+        <td>The key of the Kubernetes secret, which contains the content of the OAuth2 private key.</td>
+      </tr>
+    </table>
 
 ## Packages
 

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -159,7 +159,7 @@ Function Mesh provides the `tlsConfig`, `tlsSecret`, `authSecret`, `authConfig` 
       </tr>
       <tr>
         <td><code>issuerUrl</code></td>
-        <td>The URL of the authentication provider which allows a Pulsar client to obtain an access token.</td>
+        <td>The URL of the authentication provider that allows a Pulsar client to obtain an access token.</td>
       </tr>
       <tr>
         <td><code>scope</code></td>

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -148,7 +148,7 @@ Then, in the Pulsar Functions and Connectors, you can call `context.getSecret("u
 
 ## Authentication
 
-Function Mesh provides the `tlsConfig`, `tlsSecret`, and `authSecret` fields for Function, Source, and Sink in the CRD definition. You can configure TLS encryption and/or TLS authentication using the following configurations.
+Function Mesh provides the `tlsConfig`, `tlsSecret`, `authSecret`, `authConfig` fields for Function, Source, and Sink in the CRD definition. You can configure TLS encryption, TLS authentication, and OAuth2 authentication using the following configurations.
 
 > **Note**
 > 
@@ -178,6 +178,42 @@ Function Mesh provides the `tlsConfig`, `tlsSecret`, and `authSecret` fields for
     | --- | --- |
     | `clientAuthenticationPlugin` | The client authentication plugin. |
     | `clientAuthenticationParameters` | The client authentication parameters. |
+
+- Authentication configurations
+
+  > **Note**
+  >
+  > Currently, only [OAuth2 authentication](https://oauth.net/) configurations are supported. For other authentication methods, you can configure them using the Authentication Secret.
+
+    <table>
+      <tr>
+        <th>Field</th>
+        <th>Description</th>
+      </tr>
+      <tr>
+        <td colspan="2"><b>OAuth2 authentication</b></td>
+      </tr>
+      <tr>
+        <td><code>audience</code></td>
+        <td>The OAuth2 "resource server" identifier for the Pulsar cluster.</td>
+      </tr>
+      <tr>
+        <td><code>issuerUrl</code></td>
+        <td>The URL of the authentication provider which allows a Pulsar client to obtain an access token.</td>
+      </tr>
+      <tr>
+        <td><code>scope</code></td>
+        <td>The scope of an access request. For more information, see [access token scope](https://datatracker.ietf.org/doc/html/rfc6749#section-3.3).</td>
+      </tr>
+      <tr>
+        <td><code>keySecretName</code></td>
+        <td>The name of the Kubernetes secret.</td>
+      </tr>
+      <tr>
+        <td><code>keySecretKey</code></td>
+        <td>The key of the Kubernetes secret, which contains the content of the OAuth2 private key.</td>
+      </tr>
+    </table>
 
 ## Packages
 

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -199,7 +199,7 @@ Function Mesh provides the `tlsConfig`, `tlsSecret`, `authSecret`, `authConfig` 
       </tr>
       <tr>
         <td><code>issuerUrl</code></td>
-        <td>The URL of the authentication provider which allows a Pulsar client to obtain an access token.</td>
+        <td>The URL of the authentication provider that allows a Pulsar client to obtain an access token.</td>
       </tr>
       <tr>
         <td><code>scope</code></td>


### PR DESCRIPTION
### Motivation

Function Mesh v0.6.0 support OAuth2 configs ([code PR #447]( https://github.com/streamnative/function-mesh/pull/447)), therefore add docs accordingly.

### Modification

- Update the Function / Source / Sink CRD configuration docs