### PR TITLE
[FMv0.6]--Update docs about auth support in Mesh Worker Service

### DIFF
--- a/docs/function-mesh-worker/deploy-mesh-worker.md
+++ b/docs/function-mesh-worker/deploy-mesh-worker.md
@@ -12,7 +12,6 @@ This document describes how to deploy the Function Mesh Worker service.
 > - Function Mesh Worker service cannot manage the FunctionMesh CRD.
 > - You need to configure the `clusterName`, `inputTypeClassName`, `outputTypeClassName` parameters through the `custom-runtime-options` option when creating or updating Pulsar functions or connectors.
 > - You need to manually manage the [`ConfigMap`](/functions/function-crd.md#cluster-location), such as the Pulsar service URL.
-> - A Pulsar cluster with the Function Mesh Worker service should be the same Kubernetes cluster where the Function Mesh Operator is deployed.
 
 ## Deploy Function Mesh Worker service separately
 

--- a/docs/function-mesh-worker/function-mesh-worker-overview.md
+++ b/docs/function-mesh-worker/function-mesh-worker-overview.md
@@ -24,8 +24,6 @@ In previous releases, Function Mesh Worker service used the super admin account 
 >
 > Currently, only OAuth2 authentication is supported.
 
-> NOTE: if you are using Pulsar cluster with other authentication providers, the Function Mesh Worker Service will not work
-
 ### OAuth2 authentication
 
 For clients that use OAuth2 authentication, you need to create a Kubernetes Secret in advance in the same cluster where Function Mesh operators work. The Kubernetes Secret is something like the below:
@@ -58,4 +56,4 @@ This table lists the version mapping relationships between Function Mesh and Fun
 | v0.2.0| <br />- v2.10.0.5-v2.10.0.6 <br />- v2.9.2.18-v2.9.2.22 <br />- v2.8.3.4 |
 | v0.3.0| <br />- v2.10.0.7 <br />- v2.9.2.23+ <br />- v2.8.3.5+ |
 | v0.4.0| <br />- v2.10.1.4+ <br />- v2.9.3.3+ <br />- v2.8.3.6+ |
-| v0.5.0| <br />- v2.10.1.7+ <br />- v2.9.3.5+ <br />- v2.8.4.1+ |
+| v0.5.0| <br />- v2.10.1.7 ~ v2.10.1.8 <br />- v2.9.3.6 ~ v2.9.3.8  <br />- v2.8.4.1 |

--- a/docs/function-mesh-worker/function-mesh-worker-overview.md
+++ b/docs/function-mesh-worker/function-mesh-worker-overview.md
@@ -16,17 +16,19 @@ The following figure illustrates how Function Mesh Worker service works with Pul
 
 ![Function Mesh Workflow](./../assets/function-mesh-workflow.png)
 
-## Authentication Support
+## Authentication
 
-Before v0.6.0, the Function Mesh Worker Service uses a super admin Pulsar account reading from the config file for Function Mesh operators, which is not secure, so start from v0.6.0, there is a break change to use separate account for each user.
+In previous releases, Function Mesh Worker service used the super admin account to read the configuration file for Function Mesh operators, which is not secure. Therefore, starting from this release, Function Mesh Worker service supports setting a separate account for each user.
 
-**Currently it only support OAuth2 providers, other providers will be supported as soon as possible.**
+> **Note**
+>
+> Currently, only OAuth2 authentication is supported.
 
 > NOTE: if you are using Pulsar cluster with other authentication providers, the Function Mesh Worker Service will not work
 
-### OAuth2
+### OAuth2 authentication
 
-For each client of OAuth2, there should be a Kubernetes Secret created in advance in the same cluster of Function Mesh operators, its format is like below:
+For clients that use OAuth2 authentication, you need to create a Kubernetes Secret in advance in the same cluster where Function Mesh operators work. The Kubernetes Secret is something like the below:
 
 ```yaml
 apiVersion: v1

--- a/docs/function-mesh-worker/function-mesh-worker-overview.md
+++ b/docs/function-mesh-worker/function-mesh-worker-overview.md
@@ -16,6 +16,34 @@ The following figure illustrates how Function Mesh Worker service works with Pul
 
 ![Function Mesh Workflow](./../assets/function-mesh-workflow.png)
 
+## Authentication Support
+
+Before v0.6.0, the Function Mesh Worker Service uses a super admin Pulsar account reading from the config file for Function Mesh operators, which is not secure, so start from v0.6.0, there is a break change to use separate account for each user.
+
+**Currently it only support OAuth2 providers, other providers will be supported as soon as possible.**
+
+> NOTE: if you are using Pulsar cluster with other authentication providers, the Function Mesh Worker Service will not work
+
+### OAuth2
+
+For each client of OAuth2, there should be a Kubernetes Secret created in advance in the same cluster of Function Mesh operators, its format is like below:
+
+```yaml
+apiVersion: v1
+data:
+  auth.json: |
+    {
+      "client_id": "xxxx",
+      "client_secret": "xxxx",
+      "issuer_url": "xxx"
+    }
+  clientAuthenticationParameters: {"privateKey":"file:///${SOME-PATH-OF-FILE}","issuerUrl":"${OAUTH-ISSUER-URL}","audience":"${OAUTH-AUDIENCE}","scope":"${OAUTH-SCOPE}"}
+kind: Secret
+metadata:
+  name: ${OAUTH-CLIENT-NAME}
+type: Opaque
+```
+
 ## Version matrix
 
 This table lists the version mapping relationships between Function Mesh and Function Mesh Worker service.


### PR DESCRIPTION
### Motivation

Function Mesh Worker Service v0.6.0 support using separate auth for each user(only support OAuth2)([code PR #357](https://github.com/streamnative/function-mesh-worker-service/pull/357)), therefore add docs accordingly.

### Modification

- Update the Function Mesh Worker Service overview docs