### PR TITLE
Update sidebar files to add release note 0.6.0

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -86,7 +86,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Releases',
-      items: ['releases/release-note-0-1-4', 'releases/release-note-0-1-5', 'releases/release-note-0-1-6', 'releases/release-note-0-1-7', 'releases/release-note-0-1-8', 'releases/release-note-0-1-9', 'releases/release-note-0-2-0', 'releases/release-note-0-3-0', 'releases/release-note-0-4-0', 'releases/release-note-0-5-0'],
+      items: ['releases/release-note-0-1-4', 'releases/release-note-0-1-5', 'releases/release-note-0-1-6', 'releases/release-note-0-1-7', 'releases/release-note-0-1-8', 'releases/release-note-0-1-9', 'releases/release-note-0-2-0', 'releases/release-note-0-3-0', 'releases/release-note-0-4-0', 'releases/release-note-0-5-0', 'releases/release-note-0-6-0'],
     },
   ],
 }

--- a/versioned_sidebars/version-0.6.0-sidebars.json
+++ b/versioned_sidebars/version-0.6.0-sidebars.json
@@ -242,6 +242,10 @@
         {
           "type": "doc",
           "id": "version-0.6.0/releases/release-note-0-5-0"
+        },
+        {
+          "type": "doc",
+          "id": "version-0.6.0/releases/release-note-0-6-0"
         }
       ]
     }


### PR DESCRIPTION
### Motivation

The release note v0.6.0 is not shown in the left navigation panel. Therefore, update the `sidebar.json` files for both the `main` and `v0.6.0` branches.