### PR TITLE
[FM v0.7.0]--Use init container to download packages/functions

### DIFF
--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -18,6 +18,7 @@ This table lists sink configurations.
 | `clusterName` | The Pulsar cluster of a sink connector. |
 | `replicas`| The number of instances that you want to run for this sink connector. If no value is set, the system will set it to `1`. |
 | `minReplicas`| The minimum number of instances that you want to run for this sink connector. If no value is set, the system will set it to `1`. When HPA auto-scaling is enabled, the HPA controller scales the Pods up / down based on the values of the `minReplicas` and `maxReplicas` options. The number of the Pods should be greater than the value of the `minReplicas` and be smaller than the value of the `maxReplicas`.  |
+| `downloaderImage` | The image for installing the [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that is used to download packages or functions from Pulsar if the [download path](#packages) is specified. |
 | `maxReplicas`| The maximum number of instances that you want to run for this sink connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the sink controller automatically scales the sink connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
 | `sinkConfig` | The sink connector configurations in YAML format.|
 | `timeout` | The message timeout in milliseconds. |

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -18,6 +18,7 @@ This table lists source configurations.
 | `clusterName` | The Pulsar cluster of a source connector. |
 | `replicas`| The number of instances that you want to run for this source connector. If no value is set, the system will set it to `1`. |
 | `minReplicas`| The minimum number of instances that you want to run for this source connector. If no value is set, the system will set it to `1`. When HPA auto-scaling is enabled, the HPA controller scales the Pods up / down based on the values of the `minReplicas` and `maxReplicas` options. The number of the Pods should be greater than the value of the `minReplicas` and be smaller than the value of the `maxReplicas`.  |
+| `downloaderImage` | The image for installing the [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that is used to download packages or functions from Pulsar if the [download path](#packages) is specified. |
 | `maxReplicas`| The maximum number of instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
 | `sourceConfig` | The source connector configurations in YAML format. |
 | `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -19,6 +19,7 @@ This table lists Pulsar Function configurations.
 | `clusterName` | The Pulsar cluster of a Pulsar Function. |
 | `replicas`| The number of instances that you want to run this Pulsar Function. If no value is set, the system will set it to `1`. |
 | `minReplicas`| The minimum number of instances that you want to run for this Pulsar function. If no value is set, the system will set it to `1`. When HPA auto-scaling is enabled, the HPA controller scales the Pods up / down based on the values of the `minReplicas` and `maxReplicas` options. The number of the Pods should be greater than the value of the `minReplicas` and be smaller than the value of the `maxReplicas`.  |
+| `downloaderImage` | The image for installing the [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that is used to download packages or functions from Pulsar if the [download path](#packages) is specified. |
 | `maxReplicas`| The maximum number of instances that you want to run for this Pulsar function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
 | `timeout` | The message timeout in milliseconds. |
 | `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |


### PR DESCRIPTION
### Motivation

FM v0.7.0 introduced a config to use the init container to download packages/functions ([PR #411](https://github.com/streamnative/function-mesh/pull/411/)). Therefore, update docs accordingly.

### Modification

Update Function / Source / Sink CRD configuration docs