### PR TITLE
[FM v0.8.0]--Add doc for batchSourceConfig option

### DIFF
--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -23,7 +23,7 @@ This table lists source configurations.
 | `sourceConfig` | The source connector configurations in YAML format. |
 | `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
 | `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic.  |
-| `batchSourceConfig` | The batch source configurations in YAML format. You can configure the following properties. <br/> - `discoveryTriggererClassName`: the class that is used for triggering the discovery process. <br/> - `discoveryTriggererConfig`: the configurations that are required for the discovery Triggerer initiation. |
+| `batchSourceConfig` | The batch source configurations in YAML format. You can configure the following properties. <br/> - `discoveryTriggererClassName`: the class that is used for triggering the discovery process. <br/> - `discoveryTriggererConfig`: the configurations that are required for initiating the discovery Triggerer. |
 
 ## Annotations
 

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -22,7 +22,8 @@ This table lists source configurations.
 | `maxReplicas`| The maximum number of instances that you want to run for this source connector. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the source controller automatically scales the source connector based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
 | `sourceConfig` | The source connector configurations in YAML format. |
 | `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
-| `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic. |
+| `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic.  |
+| `batchSourceConfig` | The batch source configurations in key/value pairs. You can configure the following properties using JSON strings. <br/> - `discoveryTriggererClassName`: the class that is used for triggering the discovery process. <br/> - `discoveryTriggererConfig`: The configurations that are required for the discovery Triggerer initiation. |
 
 ## Annotations
 

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -23,7 +23,7 @@ This table lists source configurations.
 | `sourceConfig` | The source connector configurations in YAML format. |
 | `processingGuarantee` | The processing guarantees (delivery semantics) applied to the source connector. Available values: `atleast_once`, `atmost_once`, `effectively_once`.|
 | `forwardSourceMessageProperty` | Configure whether to pass message properties to a target topic.  |
-| `batchSourceConfig` | The batch source configurations in key/value pairs. You can configure the following properties using JSON strings. <br/> - `discoveryTriggererClassName`: the class that is used for triggering the discovery process. <br/> - `discoveryTriggererConfig`: The configurations that are required for the discovery Triggerer initiation. |
+| `batchSourceConfig` | The batch source configurations in YAML format. You can configure the following properties. <br/> - `discoveryTriggererClassName`: the class that is used for triggering the discovery process. <br/> - `discoveryTriggererConfig`: the configurations that are required for the discovery Triggerer initiation. |
 
 ## Annotations
 


### PR DESCRIPTION
### Motivation

The [code PR #496](https://github.com/streamnative/function-mesh/pull/496) introduces a `batchSourceConfg` for the source connector. Therefore, update the document accordingly.

### Modification

- Update the Source CRD configurations doc.