### PR TITLE
[FM v0.8]--Update docs for Java option support

### DIFF
--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -212,7 +212,8 @@ Function Mesh supports running Pulsar connectors in Java.
 
 | Field | Description |
 | --- | --- |
-| `jarLocation` | Path to the JAR file for the connector.|
+| `jarLocation` | The path to the JAR file for the connector.|
+| `javaOpts` | It specifies JVM options to better configure JVM behaviors, including `exitOnOOMError`, Garbage Collection logs, Garbage Collection tuning, and so on. |
 | `extraDependenciesDir` | It specifies the dependent directory for the JAR package. |
 
 ## Cluster location

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -205,7 +205,8 @@ Function Mesh supports running Pulsar connectors in Java.
 
 | Field | Description |
 | --- | --- |
-| `jarLocation` | Path to the JAR file for the connector. |
+| `jarLocation` | The path to the JAR file for the connector. |
+| `javaOpts` | It specifies JVM options to better configure JVM behaviors, including `exitOnOOMError`, Garbage Collection logs, Garbage Collection tuning, and so on. |
 | `extraDependenciesDir` | It specifies the dependent directory for the JAR package. |
 
 ## Cluster location

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -249,9 +249,10 @@ Function Mesh supports running Pulsar Functions in Java, Python and Go. This tab
 
 | Field | Description |
 | --- | --- |
-| `jarLocation` | Path to the JAR file for the function. It is only available for Pulsar functions written in Java. |
-| `goLocation` | Path to the JAR file for the function. It is only available for Pulsar functions written in Go.|
-| `pyLocation` | Path to the JAR file for the function. It is only available for Pulsar functions written in Python.|
+| `jarLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Java. |
+| `javaOpts` | It specifies JVM options to better configure JVM behaviors, including `exitOnOOMError`, Garbage Collection logs, Garbage Collection tuning, and so on. |
+| `goLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Go.|
+| `pyLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Python.|
 | `extraDependenciesDir` | It specifies the dependent directory for the JAR package. |
 
 ## Log levels


### PR DESCRIPTION
### Motivation

FM v0.8.0 supports a java option to customize JVM options to configure JVM behaviors better ([code PR](https://github.com/streamnative/function-mesh/pull/484)). Therefore, update docs accordingly.

### Modification

- Update functions/source/sink CRD configurations