### PR TITLE
Fix code comment format

### DIFF
--- a/docs/connectors/io-crd-config/sink-crd-config.md
+++ b/docs/connectors/io-crd-config/sink-crd-config.md
@@ -246,8 +246,8 @@ spec:
   replicas: 1
   maxReplicas: 5
   liveness:
-    initialDelaySeconds: 10        --- [1]
-    periodSeconds: 10              --- [2]
+    initialDelaySeconds: 10        # --- [1]
+    periodSeconds: 10              # --- [2]
   logTopic: persistent://public/default/logging-function-logs
 ... 
 # Other configs

--- a/docs/connectors/io-crd-config/source-crd-config.md
+++ b/docs/connectors/io-crd-config/source-crd-config.md
@@ -240,8 +240,8 @@ spec:
   replicas: 1
   maxReplicas: 5
   liveness:
-    initialDelaySeconds: 10        --- [1]
-    periodSeconds: 10              --- [2]
+    initialDelaySeconds: 10        # --- [1]
+    periodSeconds: 10              # --- [2]
   logTopic: persistent://public/default/logging-function-logs
 ... 
 # Other configs

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -321,8 +321,8 @@ spec:
   replicas: 1
   maxReplicas: 5
   liveness:
-    initialDelaySeconds: 10        --- [1]
-    periodSeconds: 10              --- [2]
+    initialDelaySeconds: 10        # --- [1]
+    periodSeconds: 10              # --- [2]
   logTopic: persistent://public/default/logging-function-logs
 ... 
 # Other configs

--- a/docs/functions/produce-function-log.md
+++ b/docs/functions/produce-function-log.md
@@ -23,9 +23,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                     --- [1]
-    log:                    --- [2]
-      level: "debug"        --- [3]
+  java:                     # --- [1]
+    log:                    # --- [2]
+      level: "debug"        # --- [3]
 ```
 
 - [1] `java`: represents the runtime with a specific programming language. Currently, available options include the Java runtime, the Python runtime, and the Go runtime.
@@ -41,9 +41,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                                 --- [1]
-    log:                                --- [2]
-      logConfig:                        --- [3]
+  java:                                 # --- [1]
+    log:                                # --- [2]
+      logConfig:                        # --- [3]
         name: "java-log-config-cm"
         key: "java-config-xml"
 ---
@@ -57,7 +57,7 @@ data:
         <name>pulsar-functions-kubernetes-instance</name>
         <monitorInterval>30</monitorInterval>
         <Properties>
-            <Property>                   --- [4]
+            <Property>                   # --- [4]
                 <name>pulsar.log.level</name>       
                 <value>DEBUG</value>
             </Property>
@@ -66,7 +66,7 @@ data:
                 <value>DEBUG</value>
             </Property>
         </Properties>
-        <Appenders>                      --- [5]
+        <Appenders>                      # --- [5]
             <Console>
                 <name>Console</name>          
                 <target>SYSTEM_OUT</target>
@@ -76,11 +76,11 @@ data:
             </Console>
         </Appenders>
         <Loggers>            
-            <Logger>                     --- [6]
+            <Logger>                     # --- [6]
                 <name>org.apache.pulsar.functions.runtime.shaded.org.apache.bookkeeper</name>
                 <level>${sys:bk.log.level}</level>
-                <additivity>false</additivity>              --- [7]
-                <AppenderRef>                               --- [8]
+                <additivity>false</additivity>              # --- [7]
+                <AppenderRef>                               # --- [8]
                     <ref>Console</ref>
                 </AppenderRef>
             </Logger>
@@ -119,9 +119,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                                                 --- [1]
-    log:                                                --- [2]
-      rotatePolicy: "TimedPolicyWithDaily"              --- [3]        
+  java:                                                 # --- [1]
+    log:                                                # --- [2]
+      rotatePolicy: "TimedPolicyWithDaily"              # --- [3]        
 ```
 
 - [1] `java`: represents the runtime with a specific programming language. Currently, available options include the Java runtime, the Python runtime, and the Go runtime.

--- a/docs/functions/run-function/run-window-function.md
+++ b/docs/functions/run-function/run-window-function.md
@@ -36,8 +36,8 @@ This section describes how to submit a window function through a function CRD.
       maxPendingAsyncRequests: 1000
       minReplicas: 1
       windowConfig:
-        windowLengthCount: 10       --- [1]
-        slidingIntervalCount: 5     --- [2]
+        windowLengthCount: 10       # --- [1]
+        slidingIntervalCount: 5     # --- [2]
       logTopic: persistent://public/default/logging-function-logs
       input:
         topics:

--- a/docs/scaling.md
+++ b/docs/scaling.md
@@ -120,14 +120,14 @@ This example shows how to auto-scale the number of Pods to `8` when 20% CPU is u
       forwardSourceMessageProperty: true
       maxPendingAsyncRequests: 1000
       replicas: 1
-      maxReplicas: 4                    --- [1]
+      maxReplicas: 4                    # --- [1]
       logTopic: persistent://public/default/logging-function-logs                    
       input:                   
         topics:                    
         - persistent://public/default/java-function-input-topic                    
         typeClassName: java.lang.String                    
       pod:                    
-        builtinAutoscaler:               --- [2]
+        builtinAutoscaler:               # --- [2]
           - AverageUtilizationCPUPercent20
       # Other function configs
     ```
@@ -160,16 +160,16 @@ Function Mesh supports automatically scaling up the number of Pods based on a cu
         forwardSourceMessageProperty: true
         maxPendingAsyncRequests: 1000
         replicas: 1
-        maxReplicas: 4                         --- [1]
+        maxReplicas: 4                         # --- [1]
         logTopic: persistent://public/default/logging-function-logs            
         pod:            
-          autoScalingMetrics:                  --- [2]
+          autoScalingMetrics:                  # --- [2]
           - type: Resource           
             resource:            
-              name: cpu                        --- [3]
+              name: cpu                        # --- [3]
               target:             
                 type: Utilization              
-                averageUtilization: 45         --- [4]
+                averageUtilization: 45         # --- [4]
         # Other function configs
       ```
 
@@ -206,16 +206,16 @@ Function Mesh supports automatically scaling up the number of Pods based on a cu
                   type: Utilization
                   averageUtilization: 80
           autoScalingBehavior:                     
-            scaleUp:                               --- [1]
-              stabilizationWindowSeconds: 120      --- [2]
-              policies:                            --- [3]
-              - type: Percent                      --- [4]
-                value: 100                         --- [5]
-                periodSeconds: 15                  --- [6]
+            scaleUp:                               # --- [1]
+              stabilizationWindowSeconds: 120      # --- [2]
+              policies:                            # --- [3]
+              - type: Percent                      # --- [4]
+                value: 100                         # --- [5]
+                periodSeconds: 15                  # --- [6]
               - type: Pods                         
                 value: 4                           
                 periodSeconds: 15                  
-              selectPolicy: Max                    --- [7]
+              selectPolicy: Max                    # --- [7]
       ```
 
      - [1] `scaleUp`: specifies the rules that are used to control scaling behavior while scaling up.
@@ -296,18 +296,18 @@ spec:
   className: org.apache.pulsar.functions.api.examples.ExclamationFunction
   forwardSourceMessageProperty: true
   maxPendingAsyncRequests: 1000
-  replicas: 2                    --- [1]
+  replicas: 2                    # --- [1]
   pod:
     vpa:
       updatePolicy:
-        updateMode: "Auto"       --- [2]
+        updateMode: "Auto"       # --- [2]
       resourcePolicy:
         containerPolicies:
-        - containerName: "*"     --- [3]
-          minAllowed:            --- [4]
+        - containerName: "*"     # --- [3]
+          minAllowed:            # --- [4]
             cpu: 200m
             memory: 100Mi
-          maxAllowed:            --- [5]
+          maxAllowed:            # --- [5]
             cpu: 1
             memory: 1000Mi
 
@@ -346,7 +346,7 @@ spec:
       resourcePolicy:
         containerPolicies:
         - containerName: "*"
-          controlledValues: "RequestsOnly"  --- [1]
+          controlledValues: "RequestsOnly"  # --- [1]
 
   # Other function configs
 ```
@@ -377,7 +377,7 @@ spec:
       resourcePolicy:
         containerPolicies:
         - containerName: "*"
-          controlledResources: ["cpu"]   --- [1]
+          controlledResources: ["cpu"]   # --- [1]
 
   # Other function configs
 ```

--- a/versioned_docs/version-0.5.0/functions/produce-function-log.md
+++ b/versioned_docs/version-0.5.0/functions/produce-function-log.md
@@ -23,9 +23,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                     --- [1]
-    log:                    --- [2]
-      level: "debug"        --- [3]
+  java:                     # --- [1]
+    log:                    # --- [2]
+      level: "debug"        # --- [3]
 ```
 
 - [1] `java`: represents the runtime with a specific programming language. Currently, available options include the Java runtime, the Python runtime, and the Go runtime.
@@ -41,9 +41,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                                 --- [1]
-    log:                                --- [2]
-      logConfig:                        --- [3]
+  java:                                 # --- [1]
+    log:                                # --- [2]
+      logConfig:                        # --- [3]
         name: "java-log-config-cm"
         key: "java-config-xml"
 ---
@@ -57,7 +57,7 @@ data:
         <name>pulsar-functions-kubernetes-instance</name>
         <monitorInterval>30</monitorInterval>
         <Properties>
-            <Property>                   --- [4]
+            <Property>                   # --- [4]
                 <name>pulsar.log.level</name>       
                 <value>DEBUG</value>
             </Property>
@@ -66,7 +66,7 @@ data:
                 <value>DEBUG</value>
             </Property>
         </Properties>
-        <Appenders>                      --- [5]
+        <Appenders>                      # --- [5]
             <Console>
                 <name>Console</name>          
                 <target>SYSTEM_OUT</target>
@@ -76,11 +76,11 @@ data:
             </Console>
         </Appenders>
         <Loggers>            
-            <Logger>                     --- [6]
+            <Logger>                     # --- [6]
                 <name>org.apache.pulsar.functions.runtime.shaded.org.apache.bookkeeper</name>
                 <level>${sys:bk.log.level}</level>
-                <additivity>false</additivity>              --- [7]
-                <AppenderRef>                               --- [8]
+                <additivity>false</additivity>              # --- [7]
+                <AppenderRef>                               # --- [8]
                     <ref>Console</ref>
                 </AppenderRef>
             </Logger>

--- a/versioned_docs/version-0.6.0/functions/produce-function-log.md
+++ b/versioned_docs/version-0.6.0/functions/produce-function-log.md
@@ -23,9 +23,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                     --- [1]
-    log:                    --- [2]
-      level: "debug"        --- [3]
+  java:                     # --- [1]
+    log:                    # --- [2]
+      level: "debug"        # --- [3]
 ```
 
 - [1] `java`: represents the runtime with a specific programming language. Currently, available options include the Java runtime, the Python runtime, and the Go runtime.
@@ -41,9 +41,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                                 --- [1]
-    log:                                --- [2]
-      logConfig:                        --- [3]
+  java:                                 # --- [1]
+    log:                                # --- [2]
+      logConfig:                        # --- [3]
         name: "java-log-config-cm"
         key: "java-config-xml"
 ---
@@ -57,7 +57,7 @@ data:
         <name>pulsar-functions-kubernetes-instance</name>
         <monitorInterval>30</monitorInterval>
         <Properties>
-            <Property>                   --- [4]
+            <Property>                   # --- [4]
                 <name>pulsar.log.level</name>       
                 <value>DEBUG</value>
             </Property>
@@ -66,7 +66,7 @@ data:
                 <value>DEBUG</value>
             </Property>
         </Properties>
-        <Appenders>                      --- [5]
+        <Appenders>                      # --- [5]
             <Console>
                 <name>Console</name>          
                 <target>SYSTEM_OUT</target>
@@ -76,11 +76,11 @@ data:
             </Console>
         </Appenders>
         <Loggers>            
-            <Logger>                     --- [6]
+            <Logger>                     # --- [6]
                 <name>org.apache.pulsar.functions.runtime.shaded.org.apache.bookkeeper</name>
                 <level>${sys:bk.log.level}</level>
-                <additivity>false</additivity>              --- [7]
-                <AppenderRef>                               --- [8]
+                <additivity>false</additivity>              # --- [7]
+                <AppenderRef>                               # --- [8]
                     <ref>Console</ref>
                 </AppenderRef>
             </Logger>
@@ -119,9 +119,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                                                 --- [1]
-    log:                                                --- [2]
-      rotatePolicy: "TimedPolicyWithDaily"              --- [3]        
+  java:                                                 # --- [1]
+    log:                                                # --- [2]
+      rotatePolicy: "TimedPolicyWithDaily"              # --- [3]        
 ```
 
 - [1] `java`: represents the runtime with a specific programming language. Currently, available options include the Java runtime, the Python runtime, and the Go runtime.

--- a/versioned_docs/version-0.6.0/functions/run-function/run-window-function.md
+++ b/versioned_docs/version-0.6.0/functions/run-function/run-window-function.md
@@ -36,8 +36,8 @@ This section describes how to submit a window function through a function CRD.
       maxPendingAsyncRequests: 1000
       minReplicas: 1
       windowConfig:
-        windowLengthCount: 10       --- [1]
-        slidingIntervalCount: 5     --- [2]
+        windowLengthCount: 10       # --- [1]
+        slidingIntervalCount: 5     # --- [2]
       logTopic: persistent://public/default/logging-function-logs
       input:
         topics:

--- a/versioned_docs/version-0.6.0/scaling.md
+++ b/versioned_docs/version-0.6.0/scaling.md
@@ -114,14 +114,14 @@ This example shows how to auto-scale the number of Pods to `8` when 20% CPU is u
       forwardSourceMessageProperty: true
       maxPendingAsyncRequests: 1000
       replicas: 1
-      maxReplicas: 4                    --- [1]
+      maxReplicas: 4                    # --- [1]
       logTopic: persistent://public/default/logging-function-logs                    
       input:                   
         topics:                    
         - persistent://public/default/java-function-input-topic                    
         typeClassName: java.lang.String                    
       pod:                    
-        builtinAutoscaler:               --- [2]
+        builtinAutoscaler:               # --- [2]
           - AverageUtilizationCPUPercent20
       # Other function configs
     ```
@@ -154,16 +154,16 @@ Function Mesh supports automatically scaling up the number of Pods based on a cu
         forwardSourceMessageProperty: true
         maxPendingAsyncRequests: 1000
         replicas: 1
-        maxReplicas: 4                         --- [1]
+        maxReplicas: 4                         # --- [1]
         logTopic: persistent://public/default/logging-function-logs            
         pod:            
-          autoScalingMetrics:                  --- [2]
+          autoScalingMetrics:                  # --- [2]
           - type: Resource           
             resource:            
-              name: cpu                        --- [3]
+              name: cpu                        # --- [3]
               target:             
                 type: Utilization              
-                averageUtilization: 45         --- [4]
+                averageUtilization: 45         # --- [4]
         # Other function configs
       ```
 
@@ -200,16 +200,16 @@ Function Mesh supports automatically scaling up the number of Pods based on a cu
                   type: Utilization
                   averageUtilization: 80
           autoScalingBehavior:                     
-            scaleUp:                               --- [1]
-              stabilizationWindowSeconds: 120      --- [2]
-              policies:                            --- [3]
-              - type: Percent                      --- [4]
-                value: 100                         --- [5]
-                periodSeconds: 15                  --- [6]
+            scaleUp:                               # --- [1]
+              stabilizationWindowSeconds: 120      # --- [2]
+              policies:                            # --- [3]
+              - type: Percent                      # --- [4]
+                value: 100                         # --- [5]
+                periodSeconds: 15                  # --- [6]
               - type: Pods                         
                 value: 4                           
                 periodSeconds: 15                  
-              selectPolicy: Max                    --- [7]
+              selectPolicy: Max                    # --- [7]
       ```
 
      - [1] `scaleUp`: specifies the rules that are used to control scaling behavior while scaling up.

--- a/versioned_docs/version-0.7.0/functions/produce-function-log.md
+++ b/versioned_docs/version-0.7.0/functions/produce-function-log.md
@@ -23,9 +23,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                     --- [1]
-    log:                    --- [2]
-      level: "debug"        --- [3]
+  java:                     # --- [1]
+    log:                    # --- [2]
+      level: "debug"        # --- [3]
 ```
 
 - [1] `java`: represents the runtime with a specific programming language. Currently, available options include the Java runtime, the Python runtime, and the Go runtime.
@@ -41,9 +41,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                                 --- [1]
-    log:                                --- [2]
-      logConfig:                        --- [3]
+  java:                                 # --- [1]
+    log:                                # --- [2]
+      logConfig:                        # --- [3]
         name: "java-log-config-cm"
         key: "java-config-xml"
 ---
@@ -57,7 +57,7 @@ data:
         <name>pulsar-functions-kubernetes-instance</name>
         <monitorInterval>30</monitorInterval>
         <Properties>
-            <Property>                   --- [4]
+            <Property>                   # --- [4]
                 <name>pulsar.log.level</name>       
                 <value>DEBUG</value>
             </Property>
@@ -66,7 +66,7 @@ data:
                 <value>DEBUG</value>
             </Property>
         </Properties>
-        <Appenders>                      --- [5]
+        <Appenders>                      # --- [5]
             <Console>
                 <name>Console</name>          
                 <target>SYSTEM_OUT</target>
@@ -76,11 +76,11 @@ data:
             </Console>
         </Appenders>
         <Loggers>            
-            <Logger>                     --- [6]
+            <Logger>                     # --- [6]
                 <name>org.apache.pulsar.functions.runtime.shaded.org.apache.bookkeeper</name>
                 <level>${sys:bk.log.level}</level>
-                <additivity>false</additivity>              --- [7]
-                <AppenderRef>                               --- [8]
+                <additivity>false</additivity>              # --- [7]
+                <AppenderRef>                               # --- [8]
                     <ref>Console</ref>
                 </AppenderRef>
             </Logger>
@@ -119,9 +119,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                                                 --- [1]
-    log:                                                --- [2]
-      rotatePolicy: "TimedPolicyWithDaily"              --- [3]        
+  java:                                                 # --- [1]
+    log:                                                # --- [2]
+      rotatePolicy: "TimedPolicyWithDaily"              # --- [3]        
 ```
 
 - [1] `java`: represents the runtime with a specific programming language. Currently, available options include the Java runtime, the Python runtime, and the Go runtime.

--- a/versioned_docs/version-0.7.0/functions/run-function/run-window-function.md
+++ b/versioned_docs/version-0.7.0/functions/run-function/run-window-function.md
@@ -36,8 +36,8 @@ This section describes how to submit a window function through a function CRD.
       maxPendingAsyncRequests: 1000
       minReplicas: 1
       windowConfig:
-        windowLengthCount: 10       --- [1]
-        slidingIntervalCount: 5     --- [2]
+        windowLengthCount: 10       # --- [1]
+        slidingIntervalCount: 5     # --- [2]
       logTopic: persistent://public/default/logging-function-logs
       input:
         topics:

--- a/versioned_docs/version-0.7.0/scaling.md
+++ b/versioned_docs/version-0.7.0/scaling.md
@@ -114,14 +114,14 @@ This example shows how to auto-scale the number of Pods to `8` when 20% CPU is u
       forwardSourceMessageProperty: true
       maxPendingAsyncRequests: 1000
       replicas: 1
-      maxReplicas: 4                    --- [1]
+      maxReplicas: 4                    # --- [1]
       logTopic: persistent://public/default/logging-function-logs                    
       input:                   
         topics:                    
         - persistent://public/default/java-function-input-topic                    
         typeClassName: java.lang.String                    
       pod:                    
-        builtinAutoscaler:               --- [2]
+        builtinAutoscaler:               # --- [2]
           - AverageUtilizationCPUPercent20
       # Other function configs
     ```
@@ -154,16 +154,16 @@ Function Mesh supports automatically scaling up the number of Pods based on a cu
         forwardSourceMessageProperty: true
         maxPendingAsyncRequests: 1000
         replicas: 1
-        maxReplicas: 4                         --- [1]
+        maxReplicas: 4                         # --- [1]
         logTopic: persistent://public/default/logging-function-logs            
         pod:            
-          autoScalingMetrics:                  --- [2]
+          autoScalingMetrics:                  # --- [2]
           - type: Resource           
             resource:            
-              name: cpu                        --- [3]
+              name: cpu                        # --- [3]
               target:             
                 type: Utilization              
-                averageUtilization: 45         --- [4]
+                averageUtilization: 45         # --- [4]
         # Other function configs
       ```
 
@@ -200,16 +200,16 @@ Function Mesh supports automatically scaling up the number of Pods based on a cu
                   type: Utilization
                   averageUtilization: 80
           autoScalingBehavior:                     
-            scaleUp:                               --- [1]
-              stabilizationWindowSeconds: 120      --- [2]
-              policies:                            --- [3]
-              - type: Percent                      --- [4]
-                value: 100                         --- [5]
-                periodSeconds: 15                  --- [6]
+            scaleUp:                               # --- [1]
+              stabilizationWindowSeconds: 120      # --- [2]
+              policies:                            # --- [3]
+              - type: Percent                      # --- [4]
+                value: 100                         # --- [5]
+                periodSeconds: 15                  # --- [6]
               - type: Pods                         
                 value: 4                           
                 periodSeconds: 15                  
-              selectPolicy: Max                    --- [7]
+              selectPolicy: Max                    # --- [7]
       ```
 
      - [1] `scaleUp`: specifies the rules that are used to control scaling behavior while scaling up.

--- a/versioned_docs/version-0.8.0/functions/produce-function-log.md
+++ b/versioned_docs/version-0.8.0/functions/produce-function-log.md
@@ -23,9 +23,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                     --- [1]
-    log:                    --- [2]
-      level: "debug"        --- [3]
+  java:                     # --- [1]
+    log:                    # --- [2]
+      level: "debug"        # --- [3]
 ```
 
 - [1] `java`: represents the runtime with a specific programming language. Currently, available options include the Java runtime, the Python runtime, and the Go runtime.
@@ -41,9 +41,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                                 --- [1]
-    log:                                --- [2]
-      logConfig:                        --- [3]
+  java:                                 # --- [1]
+    log:                                # --- [2]
+      logConfig:                        # --- [3]
         name: "java-log-config-cm"
         key: "java-config-xml"
 ---
@@ -57,7 +57,7 @@ data:
         <name>pulsar-functions-kubernetes-instance</name>
         <monitorInterval>30</monitorInterval>
         <Properties>
-            <Property>                   --- [4]
+            <Property>                   # --- [4]
                 <name>pulsar.log.level</name>       
                 <value>DEBUG</value>
             </Property>
@@ -66,7 +66,7 @@ data:
                 <value>DEBUG</value>
             </Property>
         </Properties>
-        <Appenders>                      --- [5]
+        <Appenders>                      # --- [5]
             <Console>
                 <name>Console</name>          
                 <target>SYSTEM_OUT</target>
@@ -76,11 +76,11 @@ data:
             </Console>
         </Appenders>
         <Loggers>            
-            <Logger>                     --- [6]
+            <Logger>                     # --- [6]
                 <name>org.apache.pulsar.functions.runtime.shaded.org.apache.bookkeeper</name>
                 <level>${sys:bk.log.level}</level>
-                <additivity>false</additivity>              --- [7]
-                <AppenderRef>                               --- [8]
+                <additivity>false</additivity>              # --- [7]
+                <AppenderRef>                               # --- [8]
                     <ref>Console</ref>
                 </AppenderRef>
             </Logger>
@@ -119,9 +119,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                                                 --- [1]
-    log:                                                --- [2]
-      rotatePolicy: "TimedPolicyWithDaily"              --- [3]        
+  java:                                                 # --- [1]
+    log:                                                # --- [2]
+      rotatePolicy: "TimedPolicyWithDaily"              # --- [3]        
 ```
 
 - [1] `java`: represents the runtime with a specific programming language. Currently, available options include the Java runtime, the Python runtime, and the Go runtime.

--- a/versioned_docs/version-0.8.0/functions/run-function/run-window-function.md
+++ b/versioned_docs/version-0.8.0/functions/run-function/run-window-function.md
@@ -36,8 +36,8 @@ This section describes how to submit a window function through a function CRD.
       maxPendingAsyncRequests: 1000
       minReplicas: 1
       windowConfig:
-        windowLengthCount: 10       --- [1]
-        slidingIntervalCount: 5     --- [2]
+        windowLengthCount: 10       # --- [1]
+        slidingIntervalCount: 5     # --- [2]
       logTopic: persistent://public/default/logging-function-logs
       input:
         topics:

--- a/versioned_docs/version-0.8.0/scaling.md
+++ b/versioned_docs/version-0.8.0/scaling.md
@@ -120,14 +120,14 @@ This example shows how to auto-scale the number of Pods to `8` when 20% CPU is u
       forwardSourceMessageProperty: true
       maxPendingAsyncRequests: 1000
       replicas: 1
-      maxReplicas: 4                    --- [1]
+      maxReplicas: 4                    # --- [1]
       logTopic: persistent://public/default/logging-function-logs                    
       input:                   
         topics:                    
         - persistent://public/default/java-function-input-topic                    
         typeClassName: java.lang.String                    
       pod:                    
-        builtinAutoscaler:               --- [2]
+        builtinAutoscaler:               # --- [2]
           - AverageUtilizationCPUPercent20
       # Other function configs
     ```
@@ -160,16 +160,16 @@ Function Mesh supports automatically scaling up the number of Pods based on a cu
         forwardSourceMessageProperty: true
         maxPendingAsyncRequests: 1000
         replicas: 1
-        maxReplicas: 4                         --- [1]
+        maxReplicas: 4                         # --- [1]
         logTopic: persistent://public/default/logging-function-logs            
         pod:            
-          autoScalingMetrics:                  --- [2]
+          autoScalingMetrics:                  # --- [2]
           - type: Resource           
             resource:            
-              name: cpu                        --- [3]
+              name: cpu                        # --- [3]
               target:             
                 type: Utilization              
-                averageUtilization: 45         --- [4]
+                averageUtilization: 45         # --- [4]
         # Other function configs
       ```
 
@@ -206,16 +206,16 @@ Function Mesh supports automatically scaling up the number of Pods based on a cu
                   type: Utilization
                   averageUtilization: 80
           autoScalingBehavior:                     
-            scaleUp:                               --- [1]
-              stabilizationWindowSeconds: 120      --- [2]
-              policies:                            --- [3]
-              - type: Percent                      --- [4]
-                value: 100                         --- [5]
-                periodSeconds: 15                  --- [6]
+            scaleUp:                               # --- [1]
+              stabilizationWindowSeconds: 120      # --- [2]
+              policies:                            # --- [3]
+              - type: Percent                      # --- [4]
+                value: 100                         # --- [5]
+                periodSeconds: 15                  # --- [6]
               - type: Pods                         
                 value: 4                           
                 periodSeconds: 15                  
-              selectPolicy: Max                    --- [7]
+              selectPolicy: Max                    # --- [7]
       ```
 
      - [1] `scaleUp`: specifies the rules that are used to control scaling behavior while scaling up.
@@ -296,18 +296,18 @@ spec:
   className: org.apache.pulsar.functions.api.examples.ExclamationFunction
   forwardSourceMessageProperty: true
   maxPendingAsyncRequests: 1000
-  replicas: 2                    --- [1]
+  replicas: 2                    # --- [1]
   pod:
     vpa:
       updatePolicy:
-        updateMode: "Auto"       --- [2]
+        updateMode: "Auto"       # --- [2]
       resourcePolicy:
         containerPolicies:
-        - containerName: "*"     --- [3]
-          minAllowed:            --- [4]
+        - containerName: "*"     # --- [3]
+          minAllowed:            # --- [4]
             cpu: 200m
             memory: 100Mi
-          maxAllowed:            --- [5]
+          maxAllowed:            # --- [5]
             cpu: 1
             memory: 1000Mi
 
@@ -346,7 +346,7 @@ spec:
       resourcePolicy:
         containerPolicies:
         - containerName: "*"
-          controlledValues: "RequestsOnly"  --- [1]
+          controlledValues: "RequestsOnly"  # --- [1]
 
   # Other function configs
 ```
@@ -377,7 +377,7 @@ spec:
       resourcePolicy:
         containerPolicies:
         - containerName: "*"
-          controlledResources: ["cpu"]   --- [1]
+          controlledResources: ["cpu"]   # --- [1]
 
   # Other function configs
 ```

--- a/versioned_docs/version-0.9.0/connectors/io-crd-config/sink-crd-config.md
+++ b/versioned_docs/version-0.9.0/connectors/io-crd-config/sink-crd-config.md
@@ -246,8 +246,8 @@ spec:
   replicas: 1
   maxReplicas: 5
   liveness:
-    initialDelaySeconds: 10        --- [1]
-    periodSeconds: 10              --- [2]
+    initialDelaySeconds: 10        # --- [1]
+    periodSeconds: 10              # --- [2]
   logTopic: persistent://public/default/logging-function-logs
 ... 
 # Other configs

--- a/versioned_docs/version-0.9.0/connectors/io-crd-config/source-crd-config.md
+++ b/versioned_docs/version-0.9.0/connectors/io-crd-config/source-crd-config.md
@@ -240,8 +240,8 @@ spec:
   replicas: 1
   maxReplicas: 5
   liveness:
-    initialDelaySeconds: 10        --- [1]
-    periodSeconds: 10              --- [2]
+    initialDelaySeconds: 10        # --- [1]
+    periodSeconds: 10              # --- [2]
   logTopic: persistent://public/default/logging-function-logs
 ... 
 # Other configs

--- a/versioned_docs/version-0.9.0/functions/function-crd.md
+++ b/versioned_docs/version-0.9.0/functions/function-crd.md
@@ -321,8 +321,8 @@ spec:
   replicas: 1
   maxReplicas: 5
   liveness:
-    initialDelaySeconds: 10        --- [1]
-    periodSeconds: 10              --- [2]
+    initialDelaySeconds: 10        # --- [1]
+    periodSeconds: 10              # --- [2]
   logTopic: persistent://public/default/logging-function-logs
 ... 
 # Other configs

--- a/versioned_docs/version-0.9.0/functions/produce-function-log.md
+++ b/versioned_docs/version-0.9.0/functions/produce-function-log.md
@@ -23,9 +23,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                     --- [1]
-    log:                    --- [2]
-      level: "debug"        --- [3]
+  java:                     # --- [1]
+    log:                    # --- [2]
+      level: "debug"        # --- [3]
 ```
 
 - [1] `java`: represents the runtime with a specific programming language. Currently, available options include the Java runtime, the Python runtime, and the Go runtime.
@@ -41,9 +41,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                                 --- [1]
-    log:                                --- [2]
-      logConfig:                        --- [3]
+  java:                                 # --- [1]
+    log:                                # --- [2]
+      logConfig:                        # --- [3]
         name: "java-log-config-cm"
         key: "java-config-xml"
 ---
@@ -57,7 +57,7 @@ data:
         <name>pulsar-functions-kubernetes-instance</name>
         <monitorInterval>30</monitorInterval>
         <Properties>
-            <Property>                   --- [4]
+            <Property>                   # --- [4]
                 <name>pulsar.log.level</name>       
                 <value>DEBUG</value>
             </Property>
@@ -66,7 +66,7 @@ data:
                 <value>DEBUG</value>
             </Property>
         </Properties>
-        <Appenders>                      --- [5]
+        <Appenders>                      # --- [5]
             <Console>
                 <name>Console</name>          
                 <target>SYSTEM_OUT</target>
@@ -76,11 +76,11 @@ data:
             </Console>
         </Appenders>
         <Loggers>            
-            <Logger>                     --- [6]
+            <Logger>                     # --- [6]
                 <name>org.apache.pulsar.functions.runtime.shaded.org.apache.bookkeeper</name>
                 <level>${sys:bk.log.level}</level>
-                <additivity>false</additivity>              --- [7]
-                <AppenderRef>                               --- [8]
+                <additivity>false</additivity>              # --- [7]
+                <AppenderRef>                               # --- [8]
                     <ref>Console</ref>
                 </AppenderRef>
             </Logger>
@@ -119,9 +119,9 @@ metadata:
   name: function-sample
   namespace: default
 spec:
-  java:                                                 --- [1]
-    log:                                                --- [2]
-      rotatePolicy: "TimedPolicyWithDaily"              --- [3]        
+  java:                                                 # --- [1]
+    log:                                                # --- [2]
+      rotatePolicy: "TimedPolicyWithDaily"              # --- [3]        
 ```
 
 - [1] `java`: represents the runtime with a specific programming language. Currently, available options include the Java runtime, the Python runtime, and the Go runtime.

--- a/versioned_docs/version-0.9.0/functions/run-function/run-window-function.md
+++ b/versioned_docs/version-0.9.0/functions/run-function/run-window-function.md
@@ -36,8 +36,8 @@ This section describes how to submit a window function through a function CRD.
       maxPendingAsyncRequests: 1000
       minReplicas: 1
       windowConfig:
-        windowLengthCount: 10       --- [1]
-        slidingIntervalCount: 5     --- [2]
+        windowLengthCount: 10       # --- [1]
+        slidingIntervalCount: 5     # --- [2]
       logTopic: persistent://public/default/logging-function-logs
       input:
         topics:

--- a/versioned_docs/version-0.9.0/scaling.md
+++ b/versioned_docs/version-0.9.0/scaling.md
@@ -120,14 +120,14 @@ This example shows how to auto-scale the number of Pods to `8` when 20% CPU is u
       forwardSourceMessageProperty: true
       maxPendingAsyncRequests: 1000
       replicas: 1
-      maxReplicas: 4                    --- [1]
+      maxReplicas: 4                    # --- [1]
       logTopic: persistent://public/default/logging-function-logs                    
       input:                   
         topics:                    
         - persistent://public/default/java-function-input-topic                    
         typeClassName: java.lang.String                    
       pod:                    
-        builtinAutoscaler:               --- [2]
+        builtinAutoscaler:               # --- [2]
           - AverageUtilizationCPUPercent20
       # Other function configs
     ```
@@ -160,16 +160,16 @@ Function Mesh supports automatically scaling up the number of Pods based on a cu
         forwardSourceMessageProperty: true
         maxPendingAsyncRequests: 1000
         replicas: 1
-        maxReplicas: 4                         --- [1]
+        maxReplicas: 4                         # --- [1]
         logTopic: persistent://public/default/logging-function-logs            
         pod:            
-          autoScalingMetrics:                  --- [2]
+          autoScalingMetrics:                  # --- [2]
           - type: Resource           
             resource:            
-              name: cpu                        --- [3]
+              name: cpu                        # --- [3]
               target:             
                 type: Utilization              
-                averageUtilization: 45         --- [4]
+                averageUtilization: 45         # --- [4]
         # Other function configs
       ```
 
@@ -206,16 +206,16 @@ Function Mesh supports automatically scaling up the number of Pods based on a cu
                   type: Utilization
                   averageUtilization: 80
           autoScalingBehavior:                     
-            scaleUp:                               --- [1]
-              stabilizationWindowSeconds: 120      --- [2]
-              policies:                            --- [3]
-              - type: Percent                      --- [4]
-                value: 100                         --- [5]
-                periodSeconds: 15                  --- [6]
+            scaleUp:                               # --- [1]
+              stabilizationWindowSeconds: 120      # --- [2]
+              policies:                            # --- [3]
+              - type: Percent                      # --- [4]
+                value: 100                         # --- [5]
+                periodSeconds: 15                  # --- [6]
               - type: Pods                         
                 value: 4                           
                 periodSeconds: 15                  
-              selectPolicy: Max                    --- [7]
+              selectPolicy: Max                    # --- [7]
       ```
 
      - [1] `scaleUp`: specifies the rules that are used to control scaling behavior while scaling up.
@@ -296,18 +296,18 @@ spec:
   className: org.apache.pulsar.functions.api.examples.ExclamationFunction
   forwardSourceMessageProperty: true
   maxPendingAsyncRequests: 1000
-  replicas: 2                    --- [1]
+  replicas: 2                    # --- [1]
   pod:
     vpa:
       updatePolicy:
-        updateMode: "Auto"       --- [2]
+        updateMode: "Auto"       # --- [2]
       resourcePolicy:
         containerPolicies:
-        - containerName: "*"     --- [3]
-          minAllowed:            --- [4]
+        - containerName: "*"     # --- [3]
+          minAllowed:            # --- [4]
             cpu: 200m
             memory: 100Mi
-          maxAllowed:            --- [5]
+          maxAllowed:            # --- [5]
             cpu: 1
             memory: 1000Mi
 
@@ -346,7 +346,7 @@ spec:
       resourcePolicy:
         containerPolicies:
         - containerName: "*"
-          controlledValues: "RequestsOnly"  --- [1]
+          controlledValues: "RequestsOnly"  # --- [1]
 
   # Other function configs
 ```
@@ -377,7 +377,7 @@ spec:
       resourcePolicy:
         containerPolicies:
         - containerName: "*"
-          controlledResources: ["cpu"]   --- [1]
+          controlledResources: ["cpu"]   # --- [1]
 
   # Other function configs
 ```


### PR DESCRIPTION
### Motivation

In most of the config docs, we use `--- [number]` (such as --- [1]) to indicate a specific option which will be described in the following body text. However, this will cause an error when users copy the code directory from the doc. Therefore, we use a hashtag before the `--- [number]` (`# --- [number]`) (such as # --- [1]) to avoid such confusion.

### Modifications

- Update the comment format in config docs
- Affected releases: all releases
