### PR TITLE
[FM v0.10.0]--Support using wget to download HTTP/HTTPS packages

### DIFF
--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -248,10 +248,10 @@ Function Mesh supports running Pulsar Functions in Java, Python and Go. This tab
 
 | Field | Description |
 | --- | --- |
-| `jarLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Java. |
+| `jarLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Java. If the package file uses the HTTP or HTTPS protocol, you need to set `enable-init-containers` to `true` when you install the Function Mesh Operator. For details about how to configure the Function Mesh Operator, see [Function Mesh Operator configurations](/reference/function-mesh-config.md).|
 | `javaOpts` | It specifies JVM options to better configure JVM behaviors, including `exitOnOOMError`, Garbage Collection logs, Garbage Collection tuning, and so on. |
-| `goLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Go.|
-| `pyLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Python.|
+| `goLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Go. If the package file uses the HTTP or HTTPS protocol, you need to set `enable-init-containers` to `true` when you install the Function Mesh Operator. For details about how to configure the Function Mesh Operator, see [Function Mesh Operator configurations](/reference/function-mesh-config.md). |
+| `pyLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Python. If the package file uses the HTTP or HTTPS protocol, you need to set `enable-init-containers` to `true` when you install the Function Mesh Operator. For details about how to configure the Function Mesh Operator, see [Function Mesh Operator configurations](/reference/function-mesh-config.md).|
 | `extraDependenciesDir` | It specifies the dependent directory for the JAR package. |
 
 ## Log levels

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -248,10 +248,10 @@ Function Mesh supports running Pulsar Functions in Java, Python and Go. This tab
 
 | Field | Description |
 | --- | --- |
-| `jarLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Java.|
+| `jarLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Java. |
 | `javaOpts` | It specifies JVM options to better configure JVM behaviors, including `exitOnOOMError`, Garbage Collection logs, Garbage Collection tuning, and so on. |
-| `goLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Go. |
-| `pyLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Python. |
+| `goLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Go.|
+| `pyLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Python.|
 | `extraDependenciesDir` | It specifies the dependent directory for the JAR package. |
 
 ## Log levels

--- a/docs/functions/function-crd.md
+++ b/docs/functions/function-crd.md
@@ -19,7 +19,7 @@ This table lists Pulsar Function configurations.
 | `clusterName` | The Pulsar cluster of a Pulsar Function. |
 | `replicas`| The number of instances that you want to run this Pulsar Function. If no value is set, the system will set it to `1`. |
 | `minReplicas`| The minimum number of instances that you want to run for this Pulsar function. If no value is set, the system will set it to `1`. When HPA auto-scaling is enabled, the HPA controller scales the Pods up / down based on the values of the `minReplicas` and `maxReplicas` options. The number of the Pods should be greater than the value of the `minReplicas` and be smaller than the value of the `maxReplicas`.  |
-| `downloaderImage` | The image for installing the [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that is used to download packages or functions from Pulsar if the [download path](#packages) is specified. |
+| `downloaderImage` | The image of the [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/) that is used to download a package from Pulsar if the [download path](#packages) is specified. By default, the `downloaderImage` is an [official pulsarctl image](https://hub.docker.com/r/streamnative/pulsarctl). |
 | `maxReplicas`| The maximum number of instances that you want to run for this Pulsar function. When the value of the `maxReplicas` parameter is greater than the value of `replicas`, it indicates that the Functions controller automatically scales the Pulsar Functions based on the CPU usage. By default, `maxReplicas` is set to 0, which indicates that auto-scaling is disabled. |
 | `timeout` | The message timeout in milliseconds. |
 | `deadLetterTopic` | The topic where all messages that were not processed successfully are sent. This parameter is not supported in Python Functions. |
@@ -248,10 +248,10 @@ Function Mesh supports running Pulsar Functions in Java, Python and Go. This tab
 
 | Field | Description |
 | --- | --- |
-| `jarLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Java. If the package file uses the HTTP or HTTPS protocol, you need to set `enable-init-containers` to `true` when you install the Function Mesh Operator. For details about how to configure the Function Mesh Operator, see [Function Mesh Operator configurations](/reference/function-mesh-config.md).|
+| `jarLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Java.|
 | `javaOpts` | It specifies JVM options to better configure JVM behaviors, including `exitOnOOMError`, Garbage Collection logs, Garbage Collection tuning, and so on. |
-| `goLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Go. If the package file uses the HTTP or HTTPS protocol, you need to set `enable-init-containers` to `true` when you install the Function Mesh Operator. For details about how to configure the Function Mesh Operator, see [Function Mesh Operator configurations](/reference/function-mesh-config.md). |
-| `pyLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Python. If the package file uses the HTTP or HTTPS protocol, you need to set `enable-init-containers` to `true` when you install the Function Mesh Operator. For details about how to configure the Function Mesh Operator, see [Function Mesh Operator configurations](/reference/function-mesh-config.md).|
+| `goLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Go. |
+| `pyLocation` | The path to the JAR file for the function. It is only available for Pulsar functions written in Python. |
 | `extraDependenciesDir` | It specifies the dependent directory for the JAR package. |
 
 ## Log levels

--- a/docs/reference/function-mesh-config.md
+++ b/docs/reference/function-mesh-config.md
@@ -10,7 +10,7 @@ This table outlines the configurable parameters of the Function Mesh Operator an
 | --- | --- | --- |
 |`enable-leader-election`| Whether the Function Mesh Controller Manager should enable leader election. | `true` |
 | `enable-pprof` |Whether the Function Mesh Controller Manager should enable [pprof](https://github.com/google/pprof). | `false`|
-| `enable-init-containers` | Whether the Function Mesh Controller Manager should enable the [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/). | `false` |
+| `enable-init-containers` | Whether the Function Mesh Controller Manager should enable the [init container](https://kubernetes.io/docs/concepts/workloads/pods/init-containers/). <br />- When enabled, Function Mesh downloads an HTTP or HTTPs package through the [wget](https://www.gnu.org/software/wget/). <br />- When disabled, Function Mesh downloads an HTTP or HTTPs package through the `pulsar-admin` CLI tool. In this case, you need to grant your service account the `admin` access right. | `false` |
 |`pprof-addr`|The address of the pprof. |`:8090`|
 | `metrics-addr`| The address of the metrics. |`:8080`|
 | `health-probe-addr`|The address of the health probe. |`:8000`|


### PR DESCRIPTION
### Motivation

If the function package file uses the HTTP/HTTPS protocol, users need to have an admin access right to download them. To allow a role user to download HTTP/HTTPS package, FM v0.10.0 brings some code changes ([code PR #556](https://github.com/streamnative/function-mesh/pull/556)). Therefore, update docs accordingly.

### Modification
Update the **Packages** section in the **Function CRD configurations** document.