### PR TITLE
[FM v0.11.0]-- Add doc release note & update FM worker service version matrix

### DIFF
--- a/docs/function-mesh-worker/function-mesh-worker-overview.md
+++ b/docs/function-mesh-worker/function-mesh-worker-overview.md
@@ -62,3 +62,4 @@ This table lists the version mapping relationships between Function Mesh and Fun
 | v0.8.0| <br />- v2.10.2.1+ <br />- v2.9.3.16+ |
 | v0.9.0| <br />- v2.10.2.5+ <br />- v2.9.3.21+ |
 | v0.10.0| <br />- v2.10.3.1+ <br />- v2.9.4.2+ |
+| v0.10.0| <br />- v2.10.3.5+ <br />- v2.9.4.4+ |

--- a/docs/function-mesh-worker/function-mesh-worker-overview.md
+++ b/docs/function-mesh-worker/function-mesh-worker-overview.md
@@ -62,4 +62,4 @@ This table lists the version mapping relationships between Function Mesh and Fun
 | v0.8.0| <br />- v2.10.2.1+ <br />- v2.9.3.16+ |
 | v0.9.0| <br />- v2.10.2.5+ <br />- v2.9.3.21+ |
 | v0.10.0| <br />- v2.10.3.1+ <br />- v2.9.4.2+ |
-| v0.10.0| <br />- v2.10.3.5+ <br />- v2.9.4.4+ |
+| v0.11.0| <br />- v2.10.3.5+ <br />- v2.9.4.4+ |

--- a/docs/overview/overview.md
+++ b/docs/overview/overview.md
@@ -184,3 +184,4 @@ Figure 7. The Function Mesh architecture
   - [Release notes v0.8.0](/releases/release-note-0-8-0.md)
   - [Release notes v0.9.0](/releases/release-note-0-9-0.md)
   - [Release notes v0.10.0](/releases/release-note-0-10-0.md)
+  - [Release notes v0.11.0](/releases/release-note-0-11-0.md)  

--- a/docs/releases/release-note-0-11-0.md
+++ b/docs/releases/release-note-0-11-0.md
@@ -1,0 +1,9 @@
+---
+title: Release notes v0.11.0
+category: releases
+id: release-note-0-11-0
+---
+
+
+In this release, codes are updated to improve underlying services and do not affect user experiences. For a full list of updates available for Release v0.11.0, check out the [Function Mesh change log](https://github.com/streamnative/function-mesh/releases/tag/v0.11.0).
+

--- a/docs/releases/release-note-0-11-0.md
+++ b/docs/releases/release-note-0-11-0.md
@@ -5,5 +5,5 @@ id: release-note-0-11-0
 ---
 
 
-In this release, codes are updated to improve underlying services and do not affect user experiences. For a full list of updates available for Release v0.11.0, check out the [Function Mesh change log](https://github.com/streamnative/function-mesh/releases/tag/v0.11.0).
+In this release, codes were updated to improve underlying services and did not affect user experiences. For a full list of updates available for Release v0.11.0, check out the [Function Mesh change log](https://github.com/streamnative/function-mesh/releases/tag/v0.11.0).
 

--- a/sidebars.js
+++ b/sidebars.js
@@ -93,7 +93,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Releases',
-      items: ['releases/release-note-0-1-4', 'releases/release-note-0-1-5', 'releases/release-note-0-1-6', 'releases/release-note-0-1-7', 'releases/release-note-0-1-8', 'releases/release-note-0-1-9', 'releases/release-note-0-2-0', 'releases/release-note-0-3-0', 'releases/release-note-0-4-0', 'releases/release-note-0-5-0', 'releases/release-note-0-6-0', 'releases/release-note-0-7-0', 'releases/release-note-0-8-0', 'releases/release-note-0-9-0', 'releases/release-note-0-10-0'],
+      items: ['releases/release-note-0-1-4', 'releases/release-note-0-1-5', 'releases/release-note-0-1-6', 'releases/release-note-0-1-7', 'releases/release-note-0-1-8', 'releases/release-note-0-1-9', 'releases/release-note-0-2-0', 'releases/release-note-0-3-0', 'releases/release-note-0-4-0', 'releases/release-note-0-5-0', 'releases/release-note-0-6-0', 'releases/release-note-0-7-0', 'releases/release-note-0-8-0', 'releases/release-note-0-9-0', 'releases/release-note-0-10-0', 'releases/release-note-0-11-0'],
     }
   ],
 }


### PR DESCRIPTION
### Motivation

Function Mesh v0.110.0 is released. In this release, codes are updated for underlying services and no doc-required code PRs are introduced. Therefore, add a doc release and update the Function Mesh worker service version matrix.

### Modification

- Add doc release note v0.11.0
- Update the version matrix table between Function Mesh v0.11.0 and Function Mesh worker service
- Update the Overview document: add the link to the Doc release note v0.11.0
- Update the `sidebar.json `file