### PR TITLE
[FM v0.13.0]-- Add doc release note & update FM worker service version matrix

### DIFF
--- a/docs/function-mesh-worker/function-mesh-worker-overview.md
+++ b/docs/function-mesh-worker/function-mesh-worker-overview.md
@@ -64,3 +64,4 @@ This table lists the version mapping relationships between Function Mesh and Fun
 | v0.10.0| <br />- v2.10.3.1+ <br />- v2.9.4.2+ |
 | v0.11.0| <br />- v2.10.3.5+ <br />- v2.9.4.4+ |
 | v0.12.0| <br />- v2.11.0.5+ <br />- v2.10.3.7+ <br />- v2.9.4.6+ |
+| v0.13.0| <br />- v2.11.0.6+ <br />- v2.10.3.8+ <br />- v2.9.4.7+ |

--- a/docs/overview/overview.md
+++ b/docs/overview/overview.md
@@ -169,6 +169,7 @@ Figure 7. The Function Mesh architecture
     - [Customizable options](/reference/function-mesh-worker/customizable-option.md)
     - [REST APIs](/reference/function-mesh-worker/rest-api.md)
 - Releases
+  - [Release notes v0.13.0](/releases/release-note-0-13-0.md)
   - [Release notes v0.12.0](/releases/release-note-0-12-0.md)
   - [Release notes v0.11.0](/releases/release-note-0-11-0.md)
   - [Release notes v0.10.0](/releases/release-note-0-10-0.md)

--- a/docs/reference/crd-config/function-crd.md
+++ b/docs/reference/crd-config/function-crd.md
@@ -99,7 +99,7 @@ Function Mesh provides Pulsar cluster configurations in the Function, Source, an
     <td><code>authConfig</code></td>
     <td>The authentication configurations of the Pulsar cluster. Currently, you can only configure generic authentication and <a href="https://oauth.net/">OAuth2 authentication</a> through this field. For other authentication methods, you can configure them using the <code>authSecret</code> field. <p><b>Generic authentication</b></p>
     <ul>
-      <li><code>clientAuthenticationParameters</code>: sp specify the client authentication parameters.</li>
+      <li><code>clientAuthenticationParameters</code>: specify the client authentication parameters.</li>
       <li><code>clientAuthenticationPlugin</code>: specify the client authentication plugin.</li>
     </ul>
     <p><b>OAuth2 authentication</b></p>

--- a/docs/releases/release-note-0-13-0.md
+++ b/docs/releases/release-note-0-13-0.md
@@ -8,3 +8,20 @@ Here are some highlights of this release. For a full list of updates available f
 
 ## Add generic authentication configurations
 
+In this release, Function Mesh introduced the `pulsar.authConfig.genericAuth` option to configure authentication parameters of the Pulsar cluster, as shown below. For details, see [messaging](/reference/crd-config/function-crd.md#messaging).
+
+```yaml
+pulsar:
+  properties:
+    authConfig:
+      properties:
+        genericAuth:
+          properties:
+            clientAuthenticationParameters:
+            clientAuthenticationPlugin:
+# other configs
+```
+
+## Revamp documentation structure
+
+In previous releases, reference topics, such as CRD configurations of the Pulsar functions, sources, and sinks, are scattered in different sections. In this release, we revamped the doc structure by moving all reference topics to the **Reference** section, making it easier for you to access required information as required.

--- a/docs/releases/release-note-0-13-0.md
+++ b/docs/releases/release-note-0-13-0.md
@@ -1,0 +1,10 @@
+---
+title: Release notes v0.13.0
+category: releases
+id: release-note-0-13-0
+---
+
+Here are some highlights of this release. For a full list of updates available for Release v0.13.0, check out the [Function Mesh change log](https://github.com/streamnative/function-mesh/releases/tag/v0.13.0).
+
+## Add generic authentication configurations
+

--- a/sidebars.js
+++ b/sidebars.js
@@ -91,8 +91,8 @@ module.exports = {
     },
     {
       type: 'category',
-      label: 'Releases',
-      items: ['releases/release-note-0-12-0','releases/release-note-0-11-0', 'releases/release-note-0-10-0', 'releases/release-note-0-9-0', 'releases/release-note-0-8-0', 'releases/release-note-0-7-0', 'releases/release-note-0-6-0', 'releases/release-note-0-5-0', 'releases/release-note-0-4-0', 'releases/release-note-0-3-0', 'releases/release-note-0-2-0', 'releases/release-note-0-1-11', 'releases/release-note-0-1-9', 'releases/release-note-0-1-8','releases/release-note-0-1-7','releases/release-note-0-1-6','releases/release-note-0-1-5','releases/release-note-0-1-4'],
+      label: 'Release Notes',
+      items: ['releases/release-note-0-13-0','releases/release-note-0-12-0','releases/release-note-0-11-0', 'releases/release-note-0-10-0', 'releases/release-note-0-9-0', 'releases/release-note-0-8-0', 'releases/release-note-0-7-0', 'releases/release-note-0-6-0', 'releases/release-note-0-5-0', 'releases/release-note-0-4-0', 'releases/release-note-0-3-0', 'releases/release-note-0-2-0', 'releases/release-note-0-1-11', 'releases/release-note-0-1-9', 'releases/release-note-0-1-8','releases/release-note-0-1-7','releases/release-note-0-1-6','releases/release-note-0-1-5','releases/release-note-0-1-4'],
     }
   ],
 }


### PR DESCRIPTION
### Motivation

Function Mesh v0.13.0 is released. In this release, codes are updated for underlying services and no doc-required code PRs are introduced. Therefore, add a doc release and update the Function Mesh worker service version matrix table.

### Modification

- Add doc release note v0.13.0
- Update the version matrix table between Function Mesh v0.13.0 and Function Mesh worker service
- Update the Overview document: add the link to the Doc release note v0.13.0
- Update the `sidebar.json `file
- Fix typos