### PR TITLE
[FM v0.14.0]--Update Version matrix & Add Release Notes

### DIFF
--- a/docs/function-mesh-worker/function-mesh-worker-overview.md
+++ b/docs/function-mesh-worker/function-mesh-worker-overview.md
@@ -79,3 +79,4 @@ This table lists the version mapping relationships between Function Mesh and Fun
 | v0.11.0| <br />- v2.10.3.5+ <br />- v2.9.4.4+ |
 | v0.12.0| <br />- v2.11.0.5+ <br />- v2.10.3.7+ <br />- v2.9.4.6+ |
 | v0.13.0| <br />- v2.11.0.6+ <br />- v2.10.3.8+ <br />- v2.9.4.7+ |
+| v0.14.0| <br />- v3.0.0.1+ <br />- v2.11.1.3+ <br />- v2.10.4.4+ <br />- v2.9.5.2+ |

--- a/docs/overview/overview.md
+++ b/docs/overview/overview.md
@@ -169,6 +169,7 @@ Figure 7. The Function Mesh architecture
     - [Customizable options](/reference/function-mesh-worker/customizable-option.md)
     - [REST APIs](/reference/function-mesh-worker/rest-api.md)
 - Releases
+  - [Release notes v0.14.0](/releases/release-note-0-14-0.md)
   - [Release notes v0.13.0](/releases/release-note-0-13-0.md)
   - [Release notes v0.12.0](/releases/release-note-0-12-0.md)
   - [Release notes v0.11.0](/releases/release-note-0-11-0.md)

--- a/docs/releases/release-note-0-14-0.md
+++ b/docs/releases/release-note-0-14-0.md
@@ -8,7 +8,7 @@ Here are some highlights of this release. For a full list of updates available f
 
 ## Update the Statefulset configurations
 
-The `VolumeClaimTemplates` describes a list of claims that a Pod is allowed to reference. In previous releases, when you updated resources, some unmodified fields of the statefulset (or other Kubernetes resources) may be changed even with the same YAML file. This causes a failure in updating existing functions, sinks, or sources and results in an infinite reconcile loop. In this release, this property is specified at the first time when you create a function and it cannot be modified when you update the resource.
+The `VolumeClaimTemplates` describes a list of claims that a Pod is allowed to reference. In previous releases, when you updated resources, some unmodified fields of the statefulset (or other Kubernetes resources) may be changed even with the same YAML file. This causes a failure in updating existing functions, sinks, or sources and results in an infinite reconciliation loop. In this release, this property is specified at the first time when you create a function, and it cannot be modified when you update the resource.
 
 You can only update the following fields for a StatefulSet.
 
@@ -28,5 +28,5 @@ The Pulsar community introduced some `prototype` data properties. In this releas
 
 - Add the `Manual` delivery semantics to functions, sinks, and sources.
 - Add the `CompressionType` configuration to functions and sources.
-- Add the `SkipToLatest` to configuration to functions.
+- Add the `SkipToLatest` configuration to functions.
 - Deprecate the `autoAck` configuration.

--- a/docs/releases/release-note-0-14-0.md
+++ b/docs/releases/release-note-0-14-0.md
@@ -1,0 +1,32 @@
+---
+title: Release notes v0.14.0
+category: releases
+id: release-note-0-14-0
+---
+
+Here are some highlights of this release. For a full list of updates available for Release v0.14.0, check out the [Function Mesh change log](https://github.com/streamnative/function-mesh/releases/tag/v0.14.0).
+
+## Update the Statefulset configurations
+
+The `VolumeClaimTemplates` describes a list of claims that a Pod is allowed to reference. In previous releases, when you updated resources, some unmodified fields of the statefulset (or other Kubernetes resources) may be changed even with the same YAML file. This causes a failure in updating existing functions, sinks, or sources and results in an infinite reconcile loop. In this release, this property is specified at the first time when you create a function and it cannot be modified when you update the resource.
+
+You can only update the following fields for a StatefulSet.
+
+- `replicas`
+- `template`
+- `updateStrategy`
+- `persistentVolumeClaimRetentionPolicy`
+- `minReadySeconds`
+
+## Clean up subscriptions and intermediate topics
+
+Function Mesh only passes the `cleanupSubscription` to the function details, but this configuration does not work on the Function Mesh cluster. In this release, the `cleanupImage` configuration is added, which is used to remove the subscriptions created or used by a function when the function is deleted. If no clean-up image is set, the runner image will be used. In addition, you can also configure the generic or OAuth2 authentication for deleting these subscriptions and intermediate topics.
+
+## Synchronize function `prototype` data properties
+
+The Pulsar community introduced some `prototype` data properties. In this release, these properties are synchronized to Function Mesh.
+
+- Add the `Manual` delivery semantics to functions, sinks, and sources.
+- Add the `CompressionType` configuration to functions and sources.
+- Add the `SkipToLatest` to configuration to functions.
+- Deprecate the `autoAck` configuration.

--- a/sidebars.js
+++ b/sidebars.js
@@ -92,7 +92,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Release Notes',
-      items: ['releases/release-note-0-13-0','releases/release-note-0-12-0','releases/release-note-0-11-0', 'releases/release-note-0-10-0', 'releases/release-note-0-9-0', 'releases/release-note-0-8-0', 'releases/release-note-0-7-0', 'releases/release-note-0-6-0', 'releases/release-note-0-5-0', 'releases/release-note-0-4-0', 'releases/release-note-0-3-0', 'releases/release-note-0-2-0', 'releases/release-note-0-1-11', 'releases/release-note-0-1-9', 'releases/release-note-0-1-8','releases/release-note-0-1-7','releases/release-note-0-1-6','releases/release-note-0-1-5','releases/release-note-0-1-4'],
+      items: ['releases/release-note-0-14-0','releases/release-note-0-13-0','releases/release-note-0-12-0','releases/release-note-0-11-0', 'releases/release-note-0-10-0', 'releases/release-note-0-9-0', 'releases/release-note-0-8-0', 'releases/release-note-0-7-0', 'releases/release-note-0-6-0', 'releases/release-note-0-5-0', 'releases/release-note-0-4-0', 'releases/release-note-0-3-0', 'releases/release-note-0-2-0', 'releases/release-note-0-1-11', 'releases/release-note-0-1-9', 'releases/release-note-0-1-8','releases/release-note-0-1-7','releases/release-note-0-1-6','releases/release-note-0-1-5','releases/release-note-0-1-4'],
     }
   ],
 }


### PR DESCRIPTION
### Motivation

Function Mesh v0.14.0 is released. Therefore, add a doc release and update the Function Mesh worker service version matrix table.

### Modification

- Add doc release note v0.14.0
- Update the version matrix table between Function Mesh v0.14.0 and Function Mesh worker service
- Update the Overview document: add the link to the Doc release note v0.14.0
- Update the `sidebar.json `file